### PR TITLE
Fixed payload_sock not being cleared

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2596,6 +2596,7 @@ void process_udp (struct n3n_runtime_data *eee, const struct sockaddr *sender_so
                 // from here on, 'sn' gets used differently
                 for(i = 0; i < ra.num_sn; i++) {
                     n2n_sock_t payload_sock;
+                    memset(&payload_sock, 0, sizeof(payload_sock));
                     skip_add = SN_ADD;
 
                     // bugfix for https://github.com/ntop/n2n/issues/1029


### PR DESCRIPTION
This resolves #31 
The payload_sock did not clear the data, causing the value of payload_sock->type to be random, causing the memcmp comparison error of HASH_ITER in the add_sn_to_list_by_mac_or_sock function.