### PR TITLE
Add patch for OpenWrt

### DIFF
--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -32,7 +32,6 @@ define Package/n3n/Default
   TITLE:=N2N Peer-to-peer VPN
   URL:=http://github.com/n42n/n3n
   SUBMENU:=VPN
-  DEPENDS+=+libcap
 endef
 
 define Package/n3n-edge

--- a/packages/openwrt/patches/001-fix-dir.patch
+++ b/packages/openwrt/patches/001-fix-dir.patch
@@ -1,0 +1,11 @@
+--- a/src/conffile.c
++++ b/src/conffile.c
+@@ -1383,7 +1383,7 @@ int n3n_config_setup_sessiondir (n2n_edge_conf_t *conf) {
+ 
+ 
+ #ifndef _WIN32
+-    char *basedir = "/run/n3n";
++    char *basedir = "/var/run/n3n";
+ #endif
+ #ifdef _WIN32
+     char basedir[1024];


### PR DESCRIPTION
OpenWrt should use /var/run/n3n instead of /run/n3n.
The libcap is not required