### PR TITLE
Update for OpenWrt

### DIFF
--- a/packages/openwrt/Makefile
+++ b/packages/openwrt/Makefile
@@ -32,7 +32,6 @@ define Package/n3n/Default
   TITLE:=N2N Peer-to-peer VPN
   URL:=http://github.com/n42n/n3n
   SUBMENU:=VPN
-  DEPENDS+=+libcap
 endef
 
 define Package/n3n-edge
@@ -57,7 +56,7 @@ endef
 define Build/Configure
 	( cd $(PKG_BUILD_DIR); \
 	./autogen.sh; \
-	LDFLAGS=--static ./configure )
+	LDFLAGS=--static ./configure CFLAGS="-DBUILD_OPENWRT" )
 endef
 
 define Package/n3n-edge/conffiles

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -1383,7 +1383,11 @@ int n3n_config_setup_sessiondir (n2n_edge_conf_t *conf) {
 
 
 #ifndef _WIN32
+#ifndef BUILD_OPENWRT
     char *basedir = "/run/n3n";
+#else
+    char *basedir = "/tmp/run/n3n";
+#endif
 #endif
 #ifdef _WIN32
     char basedir[1024];


### PR DESCRIPTION
Use the /tmp/run/n3n directory for OpenWrt, the libcap is not required.