### PR TITLE
Fix mistaken key check for auto IP range

### DIFF
--- a/apps/n3n-supernode.c
+++ b/apps/n3n-supernode.c
@@ -505,7 +505,7 @@ int main (int argc, char * argv[]) {
         exit(1);
     }
 
-    if(ntohl(sss_node.conf.sn_min_auto_ip_net.net_addr) > ntohl(sss_node.conf.sn_max_auto_ip_net.net_bitlen)) {
+    if(ntohl(sss_node.conf.sn_min_auto_ip_net.net_addr) > ntohl(sss_node.conf.sn_max_auto_ip_net.net_addr)) {
         traceEvent(TRACE_ERROR, "auto IP min cannot be > max");
         exit(1);
     }


### PR DESCRIPTION
The previous check checked the min address against the max subnet instead of against the max address.

Basically if your configured auto net range started above 30, it would fail. (ex. 172.16.0.0...172.31.255.0/24 failed)

It would also wrongfully succeed with a backwards range, so long as the min value was still under the subnet of the max value. (ex. 10.200.0.0...10.15.0.0/24 succeeded)

This PR fixes that by correctly comparing the min and max address.