### PR TITLE
Remove conflicts (n2n) in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -25,7 +25,6 @@ Depends:
  ${misc:Depends},
  ${python3:Depends},
  ${shlibs:Depends},
-Conflicts: n2n
 Description: Peer-to-Peer and Layer-2 VPN network daemon
  n3n is a layer-two peer-to-peer virtual private network (VPN) which allows
  users to exploit features typical of P2P applications at network instead of


### PR DESCRIPTION
In fact, n2n and n3n's dpkg packages do not constitute a conflict. 

The filename of the executable file of n2n is `edge`, `supernode`, while the filename used by n3n is `n3n-edge`, `n3n-supernode`. The same goes for the systemd files. 

> I think this should already be a deliberate design to avoid conflict. 🤔

Since n2n and n3n's dpkg packages do not conflict, declaring `Conflicts: n2n` would be a problem for users like me who need to run multiple n2n supernodes and n3n supernodes at the same time.

So, I'd like to remove this line.