### PR TITLE
fix(edge_utils): update memcpy to use n3n_sock_t for destination

### DIFF
--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2180,7 +2180,7 @@ static int find_peer_destination (struct n3n_runtime_data * eee,
     }
 
     if(retval == 0) {
-        memcpy(destination, &(eee->curr_sn->sock), sizeof(struct sockaddr_in));
+        memcpy(destination, &(eee->curr_sn->sock), sizeof(n3n_sock_t));
         traceEvent(TRACE_DEBUG, "p2p peer %s not found, using supernode",
                    macaddr_str(mac_buf, mac_address));
 


### PR DESCRIPTION
When processing IPv6 addresses, using the smaller `sizeof(struct sockaddr_in)` causes the last 4 bytes of data to be truncated or retain old values.

This fix ensures the complete `n3n_sock_t` structure is copied correctly, resolving the IPv6 address truncation issue, which is mentioned in https://github.com/n42n/n3n/issues/21#issuecomment-4270745309.

✅ I have already tested this change, it works properly.