### PR TITLE
Fix/select ebadf loop

### DIFF
--- a/apps/n3n-edge.c
+++ b/apps/n3n-edge.c
@@ -1147,7 +1147,14 @@ int main (int argc, char* argv[]) {
 
         // we usually wait for some answer, there however are exceptions when going back to a previous runlevel
         if(seek_answer) {
-            mainloop_runonce(eee);
+            int rc = mainloop_runonce(eee);
+
+            // Critical error during bootstrap - should never happen, abort immediately
+            if(rc < 0) {
+                traceEvent(TRACE_ERROR, "mainloop critical error during bootstrap, aborting");
+                edge_term(eee);
+                return 1;
+            }
 
             // FIXME: the mainloop could wait for BOOTSTRAP_TIMEOUT, not its
             // usual timeout ?!?

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -3235,8 +3235,17 @@ int run_edge_loop (struct n3n_runtime_data *eee) {
      * readFromIPSocket() or edge_read_from_tap()
      */
 
+    int errs = 0;
+
     while(*eee->keep_running) {
-        mainloop_runonce(eee);
+        if(mainloop_runonce(eee) < 0) {
+            if(++errs >= 5) {
+                traceEvent(TRACE_ERROR, "exiting edge loop after 5 consecutive mainloop errors");
+                *eee->keep_running = false;
+            }
+        } else {
+            errs = 0;
+        }
 
         // TODO:
         // - migrate all the following regular actions into the

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -21,6 +21,7 @@
 
 #include <connslot/connslot.h>
 #include <errno.h>              // for errno, EAFNOSUPPORT
+#include <fcntl.h>              // for fcntl, F_GETFD
 #include <n3n/ethernet.h>       // for is_null_mac
 #include <n3n/initfuncs.h>      // for n3n_deinitfuncs
 #include <n3n/logging.h>        // for traceEvent
@@ -125,6 +126,16 @@ uint8_t mask2bitlen (uint32_t mask) {
     return bitlen;
 }
 
+/* Check if a socket/fd is invalid (EBADF on Unix, bad socket on Windows) */
+static int is_ebadf_fd (int fd) {
+#ifndef _WIN32
+    return (fcntl(fd, F_GETFD) == -1 && errno == EBADF);
+#else
+    int opt;
+    int len = sizeof(opt);
+    return (getsockopt((SOCKET)fd, SOL_SOCKET, SO_TYPE, (char *)&opt, &len) == SOCKET_ERROR);
+#endif
+}
 
 void close_tcp_connection (struct n3n_runtime_data *sss, n2n_tcp_connection_t *conn) {
 
@@ -2809,6 +2820,7 @@ int run_sn_loop (struct n3n_runtime_data *sss) {
     time_t last_purge_edges = 0;
     time_t last_sort_communities = 0;
     time_t last_re_reg_and_purge = 0;
+    int select_errors = 0;
 
     sss->start_time = time(NULL);
 
@@ -2836,6 +2848,10 @@ int run_sn_loop (struct n3n_runtime_data *sss) {
 
         // add the tcp connections' sockets
         HASH_ITER(hh, sss->tcp_connections, conn, tmp_conn) {
+            // skip inactive connections (already closed or pending cleanup)
+            if(conn->inactive) {
+                continue;
+            }
             //socket descriptor
             FD_SET(conn->socket_fd, &readers);
             if(conn->socket_fd > max_sock) {
@@ -2862,6 +2878,48 @@ int run_sn_loop (struct n3n_runtime_data *sss) {
         rc = select(max_sock + 1, &readers, &writers, NULL, &wait_time);
 
         now = time(NULL);
+
+        if(rc < 0) {
+            int err =
+#ifdef _WIN32
+                WSAGetLastError();
+#else
+                errno;
+#endif
+
+            /* Ignore signal interruption */
+            if(err == EINTR
+#ifdef _WIN32
+               || err == WSAEINTR
+#endif
+            ) {
+                /* do nothing, just continue loop */
+            } else {
+                select_errors++;
+                traceEvent(TRACE_WARNING, "select error (errno=%d), count=%d", err, select_errors);
+
+                if(select_errors >= 5) {
+                    traceEvent(TRACE_ERROR, "select errors exceeded threshold, exiting loop");
+                    *sss->keep_running = false;
+                } else {
+                    /* Scan TCP connections for bad FDs */
+                    n2n_tcp_connection_t *conn, *tmp_conn;
+                    HASH_ITER(hh, sss->tcp_connections, conn, tmp_conn) {
+                        if(conn->inactive) {
+                            continue;
+                        }
+                        if(is_ebadf_fd(conn->socket_fd)) {
+                            traceEvent(TRACE_WARNING, "removing bad TCP connection fd %d", conn->socket_fd);
+                            close_tcp_connection(sss, conn);
+                            HASH_DEL(sss->tcp_connections, conn);
+                            free(conn);
+                        }
+                    }
+                }
+            }
+        } else {
+            select_errors = 0;
+        }
 
         if(rc == 0) {
             if(((now - before) < wait_time.tv_sec) && (*sss->keep_running)) {


### PR DESCRIPTION

When select() returns -1 (EBADF), both Edge and Supernode previously ignored the error, entering a 100% CPU busy-loop and flooding logs.

Edge Client (Fail-Safe):

 * Action: Retry up to 5 times; if errors persist, exit gracefully.
 * Reason: Safe exit allows external supervisors (like systemd) to restart a clean process.

Supernode (Self-Healing with Threshold):
* Action: Track consecutive select errors. On each error, scan TCP connections and remove bad FDs. Exit after 5 consecutive failures.
 * Reason: Restarting a Supernode disconnects all users. We try to self-heal by removing problematic connections first. If errors persist (likely core socket issue), exit gracefully.
* Bug Fix: Inactive TCP connections were still added to fd_set, causing repeated EBADF. Fixed by skipping inactive in FD_SET loop and immediately removing from hash on detection.
