### PR TITLE
Purge stale peers in small communities

### DIFF
--- a/src/peer_info.c
+++ b/src/peer_info.c
@@ -153,12 +153,6 @@ size_t purge_peer_list (struct peer_info **peer_list,
     n2n_tcp_connection_t *conn;
     size_t retval = 0;
 
-    // If our table is small, dont bother purging it
-    // TODO: should the table size be a config param?
-    if(HASH_COUNT(*peer_list) < 16) {
-        return retval;
-    }
-
     HASH_ITER(hh, *peer_list, scan, tmp) {
         // TODO: untangle the tcp_connections usage and use
         // peer_info_validate() as the core of this loop

--- a/tests/tests-peer_info.expected
+++ b/tests/tests-peer_info.expected
@@ -1,0 +1,10 @@
+purge_peer_list boundary peers=0: removed=0 remaining=0
+purge_peer_list boundary peers=1: removed=1 remaining=0
+purge_peer_list boundary peers=3: removed=1 remaining=2
+purge_peer_list boundary peers=15: removed=1 remaining=14
+purge_peer_list boundary peers=16: removed=1 remaining=15
+purge_peer_list boundary peers=17: removed=1 remaining=16
+purge_peer_list small-list: removed=1 remaining=2
+stale purgeable peer present=0
+fresh purgeable peer present=1
+stale non-purgeable peer present=1

--- a/tests/tests_units.list
+++ b/tests/tests_units.list
@@ -4,5 +4,6 @@
 tests-auth
 tests-compress
 tests-elliptic
+tests-peer_info
 tests-transform
 tests-wire

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -18,6 +18,9 @@ TESTS+=tests-elliptic
 TESTS+=tests-transform
 TESTS+=tests-wire
 TESTS+=tests-auth
+TESTS+=tests-peer_info
+
+tests-peer_info: CPPFLAGS+=-I$(abspath ../src)
 
 .PHONY: all clean install
 all: $(TOOLS) $(TESTS)

--- a/tools/tests-peer_info.c
+++ b/tools/tests-peer_info.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) n3n contributors
+ * SPDX-License-Identifier: GPL-3.0-only
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "peer_info.h"
+
+
+static struct peer_info *add_peer (struct peer_info **peers,
+                                   uint8_t mac_suffix,
+                                   bool purgeable,
+                                   time_t last_seen) {
+
+    n2n_mac_t mac = {0, 0, 0, 0, 0, mac_suffix};
+    struct peer_info *peer = calloc(1, sizeof(*peer));
+
+    if(!peer) {
+        return NULL;
+    }
+
+    memcpy(peer->mac_addr, mac, sizeof(peer->mac_addr));
+    peer->purgeable = purgeable;
+    peer->last_seen = last_seen;
+    peer->socket_fd = -1;
+    HASH_ADD_PEER(*peers, peer);
+
+    return peer;
+}
+
+
+static bool peer_is_present (struct peer_info *peers, uint8_t mac_suffix) {
+
+    n2n_mac_t mac = {0, 0, 0, 0, 0, mac_suffix};
+    struct peer_info *peer;
+
+    HASH_FIND_PEER(peers, mac, peer);
+    return peer != NULL;
+}
+
+
+static bool test_boundary (unsigned int peer_count) {
+
+    struct peer_info *peers = NULL;
+    size_t removed;
+    size_t expected_removed = peer_count ? 1 : 0;
+    unsigned int i;
+    bool failed = false;
+
+    for(i = 0; i < peer_count; i++) {
+        if(!add_peer(&peers, i + 1, true, i ? 150 : 50)) {
+            failed = true;
+            break;
+        }
+    }
+
+    removed = purge_peer_list(&peers, -1, NULL, 100);
+    printf("purge_peer_list boundary peers=%u: removed=%zu remaining=%u\n",
+           peer_count, removed, HASH_COUNT(peers));
+
+    failed = failed
+             || removed != expected_removed
+             || HASH_COUNT(peers) != peer_count - expected_removed;
+
+    clear_peer_list(&peers);
+    return failed;
+}
+
+
+static bool test_peer_properties (void) {
+
+    struct peer_info *peers = NULL;
+    size_t removed;
+    bool stale_present;
+    bool fresh_present;
+    bool non_purgeable_present;
+    int failed;
+
+    if(!add_peer(&peers, 1, true, 50)
+       || !add_peer(&peers, 2, true, 150)
+       || !add_peer(&peers, 3, false, 50)) {
+        clear_peer_list(&peers);
+        return true;
+    }
+
+    removed = purge_peer_list(&peers, -1, NULL, 100);
+    stale_present = peer_is_present(peers, 1);
+    fresh_present = peer_is_present(peers, 2);
+    non_purgeable_present = peer_is_present(peers, 3);
+
+    printf("purge_peer_list small-list: removed=%zu remaining=%u\n",
+           removed, HASH_COUNT(peers));
+    printf("stale purgeable peer present=%d\n", stale_present);
+    printf("fresh purgeable peer present=%d\n", fresh_present);
+    printf("stale non-purgeable peer present=%d\n", non_purgeable_present);
+
+    failed = removed != 1
+             || HASH_COUNT(peers) != 2
+             || stale_present
+             || !fresh_present
+             || !non_purgeable_present;
+
+    clear_peer_list(&peers);
+    return failed;
+}
+
+
+int main (void) {
+
+    int failed = false;
+
+    failed |= test_boundary(0);
+    failed |= test_boundary(1);
+    failed |= test_boundary(3);
+    failed |= test_boundary(15);
+    failed |= test_boundary(16);
+    failed |= test_boundary(17);
+    failed |= test_peer_properties();
+
+    return failed;
+}


### PR DESCRIPTION
> **Work in progress — redesign pending**
>
> The current commit removes the small-table check in `purge_peer_list()`. Maintainer feedback clarified that retaining stale entries in small tables is intentional, so the current implementation does not respect the original design and will be replaced. Please do not treat the current patch as the final proposed solution.

## Problem being investigated

A stopped edge remained in a small community's peer table. Later broadcast attempts to that endpoint repeatedly failed with `EHOSTDOWN` / `ENETUNREACH`.

The retained record and repeated send attempts are confirmed. A separate observation in which other edges reported that the supernode was not responding remains correlated but is not proven to have the same root cause.

## Direction under consideration

Subject to further code review and testing, the revised approach will:

- preserve the intentional `< 16` small-table behavior;
- remove only the specific purgeable peer after a relevant send reports `EHOSTDOWN` or `ENETUNREACH`;
- handle broadcast/unicast and UDP/TCP lifecycles without double removal;
- add focused regression coverage for terminal and non-terminal send errors.

The implementation and tests will be updated only after this behavior has been validated and explained clearly.

## Tool use declaration

OpenAI Codex was used to assist with incident analysis, source inspection, test and patch preparation, and drafting the issue/PR text. The submitter reviewed the work and ran the reported tests. The rewritten commit will include the tool-use declaration required by `docs/Contributing.md`.

## Validation completed so far

- Reproduced the small-list behavior in a unit test.
- Ran the existing `make test.units` suite on arm64 macOS.

These results validate the observation but do not validate the superseded implementation currently in the branch.

Related: #142