### PR TITLE
Feature/ipv6 auto address

### DIFF
--- a/apps/example_edge_embed.c
+++ b/apps/example_edge_embed.c
@@ -61,10 +61,14 @@ int main () {
     subnet.net_addr = htonl(0x0a000001);    // Set ip address 10.0.0.1
     subnet.net_bitlen = 24;                 // Netmask to use
 
+    struct n2n_ip6_subnet subnet6;
+    memset(&subnet6, 0, sizeof(subnet6));   // No IPv6 address
+
     if(tuntap_open(&tuntap,
                    "edge0",             // Name of the device to create
                    TUNTAP_IP_MODE_STATIC, // IP mode; static|dhcp
                    subnet,
+                   subnet6,             // IPv6 address, zero for none
                    "DE:AD:BE:EF:01:10", // Set mac address
                    DEFAULT_MTU,         // MTU to use
                    0                    // Metric - unused in n2n on most OS

--- a/apps/n3n-edge.c
+++ b/apps/n3n-edge.c
@@ -37,6 +37,7 @@
 #include <n3n/mainloop.h>            // for mainloop_register_fd
 #include <n3n/tests.h>               // for test_hashing
 #include <n3n/random.h>              // for n3n_rand_seeds, n3n_rand_seeds_s...
+#include <n3n/strings.h>             // for ip6_subnet_to_str
 #include <n3n/transform.h>           // for n3n_transform_lookup_id
 #include <signal.h>                  // for signal, SIG_IGN, SIGPIPE, SIGCHLD
 #include <stdbool.h>
@@ -1017,6 +1018,24 @@ int main (int argc, char* argv[]) {
             break;
     }
 
+    switch(eee->conf.tuntap_ip6_mode) {
+        case TUNTAP_IP_MODE_SN_ASSIGN:
+            traceEvent(TRACE_NORMAL, "automatically assign IPv6 address by supernode");
+            break;
+        case TUNTAP_IP_MODE_STATIC:
+            traceEvent(TRACE_NORMAL, "use manually set IPv6 address");
+            break;
+        case TUNTAP_IP_MODE_DHCP:
+            traceEvent(TRACE_NORMAL, "leave the IPv6 address to an external process");
+            /* Nothing is to touch the interface's IPv6 configuration, so drop
+             * any address that was configured anyway */
+            memset(&eee->conf.tuntap_v6, 0, sizeof(eee->conf.tuntap_v6));
+            break;
+        default:
+            traceEvent(TRACE_ERROR, "unknown ip6_mode");
+            break;
+    }
+
     // mini main loop for bootstrap, not using main loop code because some of its mechanisms do not fit in here
     // for the sake of quickly establishing connection. REVISIT when a more elegant way to re-use main loop code
     // is found
@@ -1095,7 +1114,8 @@ int main (int argc, char* argv[]) {
         }
 
         if(runlevel == 2) { /* send REGISTER_SUPER to get auto ip address from a supernode */
-            if(eee->conf.tuntap_ip_mode == TUNTAP_IP_MODE_SN_ASSIGN) {
+            if((eee->conf.tuntap_ip_mode == TUNTAP_IP_MODE_SN_ASSIGN) ||
+               (eee->conf.tuntap_ip6_mode == TUNTAP_IP_MODE_SN_ASSIGN)) {
                 last_action = now;
                 eee->sn_wait = 1;
                 send_register_super(eee);
@@ -1135,6 +1155,7 @@ int main (int argc, char* argv[]) {
                            eee->conf.tuntap_dev_name,
                            eee->conf.tuntap_ip_mode,
                            eee->conf.tuntap_v4,
+                           eee->conf.tuntap_v6,
                            eee->conf.device_mac,
                            eee->conf.mtu,
                            eee->conf.metric) < 0)
@@ -1149,6 +1170,11 @@ int main (int argc, char* argv[]) {
                        inet_ntoa(*tmp),
                        eee->conf.tuntap_v4.net_bitlen,
                        macaddr_str(mac_buf, eee->device.mac_addr));
+            if(eee->conf.tuntap_v6.net_bitlen) {
+                ip6_bit_str_t ip6_bit_str = {'\0'};
+                traceEvent(TRACE_NORMAL, "local tap device IPv6: %s",
+                           ip6_subnet_to_str(ip6_bit_str, &eee->conf.tuntap_v6));
+            }
             runlevel = 5;
             // no more answers required
             seek_answer = 0;

--- a/apps/n3n-supernode.c
+++ b/apps/n3n-supernode.c
@@ -563,6 +563,21 @@ int main (int argc, char * argv[]) {
         traceEvent(TRACE_NORMAL, "supernode is listening on UDP %u (main)", ntohs(sa->sin_port));
     }
 
+    /* Ask the socket which family it ended up with, so that sending can build
+     * destinations to match it. */
+    {
+        struct sockaddr_storage bound;
+        socklen_t bound_len = sizeof(bound);
+
+        if(getsockname(sss_node.sock, (struct sockaddr *)&bound, &bound_len) == 0) {
+            sss_node.sock_family = bound.ss_family;
+        } else {
+            traceEvent(TRACE_WARNING, "getsockname failed [%s], assuming IPv4",
+                       strerror(errno));
+            sss_node.sock_family = AF_INET;
+        }
+    }
+
 #ifdef N2N_HAVE_TCP
     sss_node.tcp_sock = open_socket(
         sss_node.conf.bind_address,

--- a/apps/n3n-supernode.c
+++ b/apps/n3n-supernode.c
@@ -26,7 +26,8 @@
 #include <header_encryption.h> // for packet_header_setup_key
 #include <n3n/conffile.h>      // for n3n_config_set_option
 #include <n3n/initfuncs.h>     // for n3n_initfuncs()
-#include <n3n/logging.h>       // for traceEvent
+#include <n3n/logging.h>
+#include <n3n/strings.h>             // for ip6_subnet_to_str       // for traceEvent
 #include <n3n/supernode.h>     // for load_allowed_sn_community, calculate_s...
 #include <signal.h>            // for signal, SIGHUP, SIGINT, SIGPIPE, SIGTERM
 #include <stdbool.h>
@@ -533,6 +534,29 @@ int main (int argc, char * argv[]) {
         ip_max_str,
         sss_node.conf.sn_min_auto_ip_net.net_bitlen
     );
+
+    /* The IPv6 pool needs room between its prefix and the /64 boundary for the
+     * per community part, so anything from /64 up is unusable. */
+    if(sss_node.conf.sn_auto_ip6_net.net_bitlen == 0) {
+        traceEvent(TRACE_NORMAL, "auto ipv6 address service is disabled");
+    } else if(sss_node.conf.sn_auto_ip6_net.net_bitlen >= N2N_SN_AUTO_IP6_HOST_BITLEN) {
+        traceEvent(
+            TRACE_ERROR,
+            "invalid auto IPv6 prefix /%hhu, must be shorter than /%u",
+            sss_node.conf.sn_auto_ip6_net.net_bitlen,
+            N2N_SN_AUTO_IP6_HOST_BITLEN
+        );
+        exit(1);
+    } else {
+        ip6_bit_str_t ip6_net_str = {'\0'};
+
+        traceEvent(
+            TRACE_NORMAL,
+            "auto ipv6 address range is '%s', one /%u per community",
+            ip6_subnet_to_str(ip6_net_str, &sss_node.conf.sn_auto_ip6_net),
+            N2N_SN_AUTO_IP6_HOST_BITLEN
+        );
+    }
 
     calculate_shared_secrets(&sss_node);
 

--- a/docs/community.list.sample
+++ b/docs/community.list.sample
@@ -66,3 +66,15 @@ home 192.168.168.0/24
 #      `-a xxx.xxx.xxx.xxx` option. also, the enhanced syntax `-r -a dhcp:0.0.0.0` is
 #      still available to have more professional needs served by a full dhcp server.
 #
+#      an IPv6 network can optionally follow the IPv4 one, as a third field. it
+#      has to be a /64, because the supernode fills the remaining 64 bits with a
+#      host part derived from each edge's `connection.description`
+#
+home6 192.168.169.0/24 fd00:1234:5678:9abc::/64
+#
+#      if no IPv6 network is given here, the supernode derives one /64 per
+#      community from the `supernode.auto_ip6_net` prefix (which itself defaults
+#      to a unique local prefix), by hashing the community name. the fields are
+#      positional, so an IPv6 network can only be given together with an IPv4
+#      one.
+#

--- a/docs/configure/TapConfiguration.md
+++ b/docs/configure/TapConfiguration.md
@@ -36,7 +36,7 @@ random MAC address.
 
 ## IP Address
 
-n3n supports several ways to assign an IPv4 address to the virtual ethernet device. Support for IPv6 addresses relies on OS support.
+n3n supports several ways to assign an IPv4 address to the virtual ethernet device. The same three ways are available for IPv6, see the [IPv6](#ipv6) section below.
 
 ### Manually Assigned IP Address
 
@@ -56,20 +56,64 @@ If an edge of the community runs a DHCP server, the others could draw their IP a
 
 ### IPv6
 
-n3n supports the carriage of IPv6 packets within the n3n tunnel. n3n does not
-yet use IPv6 for transport between edges and supernodes.
+n3n supports the carriage of IPv6 packets within the n3n tunnel, and can assign
+IPv6 addresses to the TAP interface the same three ways it assigns IPv4 ones.
+This is controlled by `tuntap.address6_mode`, which is independent of the IPv4
+`tuntap.address_mode`, so an edge can take a static IPv4 address and an
+automatic IPv6 one, or any other combination.
 
-To make IPv6 carriage work you need to manually add IPv6 addresses to the TAP
-interfaces at each end. There is currently no way to specify an IPv6 address on
-the edge command line.
+Address assignment is implemented on every platform that supports IPv4 address
+assignment: Linux, macOS, FreeBSD, OpenBSD, NetBSD and Windows.
 
-For example, under Linux
+**IPv6 neighbour discovery is multicast**, so `filter.allow_multicast=true` is
+required for anything IPv6 to work at all - without it the discovery packets
+are dropped and no peer is ever resolved. Note also that IPv6 needs an MTU of
+at least 1280; the default `tuntap.mtu` of 1290 is fine, but lowering it below
+1280 makes the operating system refuse the address.
+
+#### Auto IPv6 address
+
+This is the default. The supernode derives one `/64` per community from its
+`supernode.auto_ip6_net` prefix by hashing the community name, and hands each
+edge an address out of that `/64`. The host part is derived from the edge's
+`connection.description` (the hostname by default), the same input the IPv4
+auto address uses, so it stays stable across restarts - and changing the
+hostname changes the address.
+
+By default the prefix is a unique local one, so the addresses never collide
+with globally routable space. To use your own:
+
+```ini
+[supernode]
+auto_ip6_net=fd12:3456::/32
+```
+
+The prefix has to be shorter than `/64` to leave room for the per-community
+part. Individual communities can be pre-assigned a fixed `/64` in the
+`community.list` file, see the comments in that file.
+
+#### Manually assigned IPv6 address
+
+```ini
+[tuntap]
+address6=fc00:abcd:1234::7/64
+address6_mode=static
+```
+
+The prefix length is optional and defaults to `/64`.
+
+#### Externally assigned IPv6 address
+
+Setting `address6_mode=dhcp` makes the edge leave the IPv6 configuration of the
+interface alone, for when an external process - or IPv6 stateless
+autoconfiguration - is expected to set it. In that case add the addresses
+yourself, for example under Linux
 
 on hostA:
-`[hostA] $ /sbin/ip -6 addr add fc00:abcd:1234::7/48 dev n3n0`
+`[hostA] $ /sbin/ip -6 addr add fc00:abcd:1234::7/64 dev n3n0`
 
 on hostB:
-`[hostB] $ /sbin/ip -6 addr add fc00:abcd:1234::6/48 dev n3n0`
+`[hostB] $ /sbin/ip -6 addr add fc00:abcd:1234::6/64 dev n3n0`
 
 You may find it useful to make use of `tunctl` from the uml-utilities
 package. `tunctl` allows you to bring up a TAP interface and configure addressing
@@ -79,6 +123,13 @@ interface closing (which would normally affect routing tables).
 Once the IPv6 addresses are configured and edge is started, IPv6 neighbor discovery
 packets flow (get broadcast) and IPv6 entities self-arrange. Test your IPv6
 setup with `ping6` - the IPv6 ping command.
+
+#### Interoperability
+
+The IPv6 subnet is carried in an optional trailing field of the registration
+messages, so edges and supernodes with and without IPv6 support interoperate:
+an older supernode simply never issues an IPv6 address, and an older edge
+ignores one that is issued to it.
 
 ## MTU
 

--- a/include/n2n.h
+++ b/include/n2n.h
@@ -96,6 +96,7 @@ int n2n_transop_zstd_init (const n2n_edge_conf_t *conf, n2n_trans_op_t *ttt);
 /* Tuntap API */
 int tuntap_open (struct tuntap_dev *device, char *dev, uint8_t address_mode,
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac, int mtu,
                  int metric);
 int tuntap_read (struct tuntap_dev *tuntap, unsigned char *buf, int len);
@@ -138,5 +139,6 @@ int comm_init (struct sn_community *comm, char *cmn);
 void sn_init (struct n3n_runtime_data *sss);
 void sn_term (struct n3n_runtime_data *sss);
 int assign_one_ip_subnet (struct n3n_runtime_data *sss, struct sn_community *comm);
+int assign_one_ip6_subnet (struct n3n_runtime_data *sss, struct sn_community *comm);
 
 #endif /* _N2N_H_ */

--- a/include/n2n_define.h
+++ b/include/n2n_define.h
@@ -135,6 +135,20 @@ enum n3n_event_topic {
 #define N2N_SN_MAX_AUTO_IP_NET_DEFAULT "10.255.255.0"
 #define N2N_SN_AUTO_IP_NET_BIT_DEFAULT 24
 
+/* Default prefix the auto IPv6 address service draws per-community /64s from.
+ * This is inside the fc00::/7 unique local range, so it never collides with
+ * globally routable addresses. */
+#define N2N_SN_AUTO_IP6_NET_DEFAULT     "fd6e:3300::"
+#define N2N_SN_AUTO_IP6_NET_BIT_DEFAULT 32
+
+/* The auto IPv6 service always hands out a full /64 so that the host part can
+ * hold an EUI-64 derived from the edge MAC. */
+#define N2N_SN_AUTO_IP6_HOST_BITLEN     64
+
+/* Smallest MTU IPv6 allows on a link (RFC 8200).  The kernel refuses to keep
+ * an IPv6 address on an interface below this. */
+#define IPV6_MIN_MTU                    1280
+
 /* ************************************** */
 
 #define SUPERNODE_IP      "127.0.0.1"

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -550,6 +550,7 @@ struct n3n_runtime_data {
     /* supernode socket is in        eee->curr_sn->sock (of type n3n_sock_t) */
     slots_t *mgmt_slots;
     int sock;
+    int sock_family;    /**< AF_INET or AF_INET6, the family 'sock' was opened with. */
 
 #ifndef SKIP_MULTICAST_PEERS_DISCOVERY
     int udp_multicast_sock_v4;                                           /**< socket for local IPv4 multicast registrations. */

--- a/include/n2n_typedefs.h
+++ b/include/n2n_typedefs.h
@@ -125,6 +125,8 @@ typedef char ipstr_t[INET_ADDRSTRLEN];
 
 typedef char dec_ip_str_t[N2N_NETMASK_STR_SIZE];
 typedef char dec_ip_bit_str_t[N2N_NETMASK_STR_SIZE + 4];
+/* INET6_ADDRSTRLEN (46) plus room for a trailing "/128" and the terminator */
+typedef char ip6_bit_str_t[52];
 typedef char devstr_t[N2N_IFNAMSIZ];
 
 
@@ -134,6 +136,8 @@ typedef struct tuntap_dev {
     devstr_t dev_name;
 #endif
     in_addr_t ip_addr;
+    uint8_t ip6_addr[16];           /* Network order, all zero when unset. */
+    uint8_t ip6_bitlen;
     n2n_mac_t mac_addr;
     uint16_t mtu;
 #ifdef _WIN32
@@ -189,6 +193,14 @@ typedef struct n2n_ip_subnet {
     uint8_t net_bitlen;             /* Subnet prefix. */
 } n2n_ip_subnet_t;
 
+/* IPv6 counterpart of n2n_ip_subnet_t.  Unlike the IPv4 version, the address
+ * is kept in network byte order throughout - there is no host-order integer
+ * wide enough to be worth converting to and from. */
+typedef struct n2n_ip6_subnet {
+    uint8_t net_addr[IPV6_SIZE];    /* Network order IPv6 address. */
+    uint8_t net_bitlen;             /* Subnet prefix length, 0 means unset. */
+} n2n_ip6_subnet_t;
+
 typedef struct n2n_sock {
     uint8_t family;                   /* AF_INET, AF_INET6 or AF_INVALID (0xff, a custom #define);
                                          mind that AF_UNSPEC (0) means auto IPv4 or IPv6 */
@@ -236,6 +248,7 @@ typedef struct n2n_REGISTER {
     n3n_sock_t sock;                /**< Supernode's view of edge socket OR edge's preferred local socket */
     n2n_ip_subnet_t dev_addr;       /**< IP address of the tuntap adapter. */
     n2n_desc_t dev_desc;            /**< Hint description correlated with the edge */
+    n2n_ip6_subnet_t dev_addr6;     /**< IPv6 address of the tuntap adapter, zero if none. */
 } n2n_REGISTER_t;
 
 typedef struct n2n_REGISTER_ACK {
@@ -262,6 +275,7 @@ typedef struct n2n_REGISTER_SUPER {
     n2n_desc_t dev_desc;            /**< Hint description correlated with the edge */
     n2n_auth_t auth;                /**< Authentication scheme and tokens */
     uint32_t key_time;              /**< key time for dynamic key, used between federatred supernodes only */
+    n2n_ip6_subnet_t dev_addr6;     /**< IPv6 address of the tuntap adapter, zero to request one. */
 } n2n_REGISTER_SUPER_t;
 
 
@@ -282,6 +296,8 @@ typedef struct n2n_REGISTER_SUPER_ACK {
                                      * even if we cannot store them all. */
 
     uint32_t key_time;              /**< key time for dynamic key, used between federatred supernodes only */
+
+    n2n_ip6_subnet_t dev_addr6;     /**< Assign an IPv6 address to the tuntap adapter of edge. */
 } n2n_REGISTER_SUPER_ACK_t;
 
 
@@ -455,7 +471,9 @@ typedef struct n2n_edge_conf {
     char *sessiondir;              // path to use for session files
     devstr_t tuntap_dev_name;
     struct n2n_ip_subnet tuntap_v4;
+    struct n2n_ip6_subnet tuntap_v6;
     uint8_t tuntap_ip_mode;                          /**< Interface IP address allocated mode, eg. DHCP. */
+    uint8_t tuntap_ip6_mode;                         /**< IPv6 address allocation mode, see TUNTAP_IP_MODE_*. */
 
     uint32_t test_benchmark_seconds;
     int test_output_format;
@@ -469,6 +487,7 @@ typedef struct n2n_edge_conf {
     struct peer_info *sn_edges;     // SN federation storage during configure
     n2n_ip_subnet_t sn_min_auto_ip_net;                        /* Address range of auto_ip service. */
     n2n_ip_subnet_t sn_max_auto_ip_net;                        /* Address range of auto_ip service. */
+    n2n_ip6_subnet_t sn_auto_ip6_net;                          /* Prefix the auto IPv6 service draws /64s from. */
 } n2n_edge_conf_t;
 
 
@@ -612,6 +631,7 @@ struct sn_community {
     sn_user_t                     *allowed_users;         /* list of allowed users */
     int64_t number_enc_packets;                           /* Number of encrypted packets handled so far, required for sorting from time to time */
     n2n_ip_subnet_t auto_ip_net;                          /* Address range of auto ip address service. */
+    n2n_ip6_subnet_t auto_ip6_net;                        /* /64 this community draws IPv6 addresses from. */
 
     UT_hash_handle hh;                                    /* makes this structure hashable */
 };

--- a/include/n3n/conffile.h
+++ b/include/n3n/conffile.h
@@ -29,6 +29,7 @@ enum n3n_conf_type {
     n3n_conf_verbose,
     n3n_conf_filter_rule,
     n3n_conf_ip_subnet,
+    n3n_conf_ip6_subnet,
     n3n_conf_ip_mode,
     n3n_conf_userid,
     n3n_conf_groupid,

--- a/include/n3n/strings.h
+++ b/include/n3n/strings.h
@@ -14,6 +14,8 @@
 
 char * ip_subnet_to_str (dec_ip_bit_str_t buf, const n2n_ip_subnet_t *ipaddr);
 
+char * ip6_subnet_to_str (ip6_bit_str_t buf, const n2n_ip6_subnet_t *ipaddr);
+
 char* sock_to_cstr (n3n_sock_str_t out,
                     const n3n_sock_t * sock);
 

--- a/scripts/hack_fakeautoconf_macos.sh
+++ b/scripts/hack_fakeautoconf_macos.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# Copyright (C) Hamish Coleman
+# SPDX-License-Identifier: GPL-2.0-only
+#
+# For macOS, where the system autotools are too old and installing newer ones
+# means pulling in a package manager just to run ./configure once.
+#
+# This writes the two files the build actually needs - an empty config.h and a
+# config.mak naming the toolchain - which is exactly what ./configure would
+# produce for a build with no optional libraries enabled.
+#
+# Optional features (zstd, openssl, miniupnpc, natpmp, pcap, cap) all need
+# their ./configure --with-* flag anyway, so leaving config.h empty simply
+# builds without them.
+#
+# Override any of these from the environment, e.g.
+#   CONFIG_PREFIX=/opt CONFIG_RUNDIR=/opt/var/run ./scripts/hack_fakeautoconf_macos.sh
+
+set -e
+
+# We assume this script is in the TOPDIR/scripts directory
+TOPDIR=$(dirname "$0")/..
+cd "$TOPDIR"
+
+CC=${CC:-cc}
+AR=${AR:-ar}
+ARCH=${ARCH:-$(uname -m)}
+
+CONFIG_PREFIX=${CONFIG_PREFIX:-/usr/local}
+CONFIG_DOCDIR=${CONFIG_DOCDIR:-${CONFIG_PREFIX}/share/doc/n3n}
+CONFIG_MANDIR=${CONFIG_MANDIR:-${CONFIG_PREFIX}/share/man}
+# macOS has /var/run, but it is not writable by an unprivileged user
+CONFIG_RUNDIR=${CONFIG_RUNDIR:-/var/run}
+# No systemd here, but the Makefile still wants the variable defined
+CONFIG_SYSTEMDDIR=${CONFIG_SYSTEMDDIR:-${CONFIG_PREFIX}/lib/systemd/system}
+
+if ! command -v "$CC" >/dev/null 2>&1; then
+    echo "Error: no '$CC' found. Install the Xcode Command Line Tools with:"
+    echo "    xcode-select --install"
+    exit 1
+fi
+
+echo "Wait please..."
+
+cat <<EOF >include/config.h
+// Created by hack fake autoconf for macOS
+// not actually a config header
+EOF
+
+cat <<EOF >include/config.h.in
+// Created by hack fake autoconf for macOS
+// not actually a config input
+EOF
+
+# autogen.sh normally copies these into place for AC_CONFIG_AUX_DIR
+cp -p scripts/config.sub.DIST scripts/config.sub
+cp -p scripts/config.guess.DIST scripts/config.guess
+
+cat >config.mak <<EOF
+# Created by hack fake autoconf for macOS
+
+CONFIG_HOST=${ARCH}-apple-darwin
+CONFIG_HOST_OS=darwin
+
+CONFIG_PREFIX=${CONFIG_PREFIX}
+CONFIG_DOCDIR=\$(DESTDIR)${CONFIG_DOCDIR}
+CONFIG_MANDIR=\$(DESTDIR)${CONFIG_MANDIR}
+CONFIG_RUNDIR=\$(DESTDIR)${CONFIG_RUNDIR}
+CONFIG_SYSTEMDDIR=\$(DESTDIR)${CONFIG_SYSTEMDDIR}
+
+CONFIG_WITH_OPENSSL=no
+
+CC=${CC}
+AR=${AR}
+WINDRES=windres
+EXE=
+
+CFLAGS+=${CFLAGS} -g -O2
+LDFLAGS+=${LDFLAGS}
+EOF
+
+echo "Generated config.mak for ${ARCH}-apple-darwin:"
+echo "  prefix  ${CONFIG_PREFIX}"
+echo "  rundir  ${CONFIG_RUNDIR}"
+echo
+echo "Now run: make"

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -64,7 +64,9 @@ static int _perf_setup1 (struct bench_item *item, int id, uint64_t config) {
         return -1;
     }
 
+#ifdef PERF_EVENT_IOC_ID
     ioctl(fd, PERF_EVENT_IOC_ID, &item->id[id]);
+#endif
     return fd;
 }
 

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -413,6 +413,36 @@ try_uint32:
             val->net_bitlen = tmp.net_bitlen;
             return 0;
         }
+        case n3n_conf_ip6_subnet: {
+            struct n2n_ip6_subnet *val = (struct n2n_ip6_subnet *)valvoid;
+            struct n2n_ip6_subnet tmp;
+            tmp.net_bitlen = N2N_SN_AUTO_IP6_HOST_BITLEN;
+
+            char *endptr;
+
+            char *bitlen_str = strchr(value, '/');
+            if(bitlen_str) {
+                // Found a prefix length, try to parse it
+                *bitlen_str++ = 0;
+                tmp.net_bitlen = strtoul(bitlen_str, &endptr, 10);
+                if(*endptr) {
+                    // there were non parsable chars in the string
+                    return -1;
+                }
+                if(tmp.net_bitlen > 128) {
+                    return -1;
+                }
+            }
+
+            if(inet_pton(AF_INET6, value, &tmp.net_addr) != 1) {
+                // error parsing
+                return -1;
+            }
+
+            memcpy(val->net_addr, tmp.net_addr, sizeof(val->net_addr));
+            val->net_bitlen = tmp.net_bitlen;
+            return 0;
+        }
         case n3n_conf_ip_mode: {
             uint8_t *val = (uint8_t *)valvoid;
 
@@ -663,6 +693,16 @@ static const char * stringify_option (void *conf, struct n3n_conf_option option,
             snprintf(buf + used, buflen - used, "/%i", val->net_bitlen);
             return buf;
         }
+        case n3n_conf_ip6_subnet: {
+            struct n2n_ip6_subnet *val = (struct n2n_ip6_subnet *)valvoid;
+
+            if(inet_ntop(AF_INET6, val->net_addr, buf, buflen) == NULL) {
+                return NULL;
+            }
+            ssize_t used = strlen(buf);
+            snprintf(buf + used, buflen - used, "/%i", val->net_bitlen);
+            return buf;
+        }
         case n3n_conf_ip_mode: {
             uint8_t *val = (uint8_t *)valvoid;
 
@@ -757,6 +797,10 @@ static int option_storagesize (const struct n3n_conf_option option) {
         }
         case n3n_conf_ip_subnet: {
             struct n2n_ip_subnet *val = (struct n2n_ip_subnet *)valvoid;
+            return sizeof(*val);
+        }
+        case n3n_conf_ip6_subnet: {
+            struct n2n_ip6_subnet *val = (struct n2n_ip6_subnet *)valvoid;
             return sizeof(*val);
         }
         case n3n_conf_ip_mode: {

--- a/src/conffile.c
+++ b/src/conffile.c
@@ -330,15 +330,18 @@ try_uint32:
                 return 0;
             }
 
-            in_addr_t address_tmp = inet_addr(value);
-            if(address_tmp == INADDR_NONE) {
-                val->family = AF_INVALID;
-                return -1;
+            if(inet_pton(AF_INET, value, &(val->addr.v4)) == 1) {
+                val->family = AF_INET;
+                return 0;
             }
 
-            memcpy(&(val->addr.v4), &(address_tmp), IPV4_SIZE);
-            val->family = AF_INET;
-            return 0;
+            if(inet_pton(AF_INET6, value, &(val->addr.v6)) == 1) {
+                val->family = AF_INET6;
+                return 0;
+            }
+
+            val->family = AF_INVALID;
+            return -1;
         }
         case n3n_conf_sn_selection: {
             uint8_t *val = (uint8_t *)valvoid;

--- a/src/conffile_defs.c
+++ b/src/conffile_defs.c
@@ -319,6 +319,20 @@ static struct n3n_conf_option section_management[] = {
 
 static struct n3n_conf_option section_supernode[] = {
     {
+        .name = "auto_ip6_net",
+        .type = n3n_conf_ip6_subnet,
+        .offset = offsetof(n2n_edge_conf_t, sn_auto_ip6_net),
+        .desc = "Prefix the auto IPv6 addresses are drawn from",
+        .help = "When the supernode is issuing IPv6 addresses to the edges "
+                "(with the edge tuntap.address6_mode option) this configures "
+                "the prefix used. The supernode derives one /64 per community "
+                "from it, and the host part of each edge is derived from the "
+                "connection.description setting. The prefix must be shorter "
+                "than /64 to leave room for the community part. Defaults to a "
+                "unique local prefix, so it never collides with globally "
+                "routable addresses.",
+    },
+    {
         .name = "auto_ip_max",
         .type = n3n_conf_ip_subnet,
         .offset = offsetof(n2n_edge_conf_t, sn_max_auto_ip_net),
@@ -451,6 +465,28 @@ static struct n3n_conf_option section_tuntap[] = {
                 "of the address_mode setting. "
                 "The address can also contain an optional trailing '/' and "
                 "subnet size.",
+    },
+    {
+        .name = "address6",
+        .type = n3n_conf_ip6_subnet,
+        .offset = offsetof(n2n_edge_conf_t, tuntap_v6),
+        .desc = "Set the tuntap IPv6 address",
+        .help = "By default, the supernode will assign an address. The "
+                "address defined here may be ignored depending on the value "
+                "of the address6_mode setting. "
+                "The address can also contain an optional trailing '/' and "
+                "prefix length, which defaults to /64.",
+    },
+    {
+        .name = "address6_mode",
+        .type = n3n_conf_ip_mode,
+        .offset = offsetof(n2n_edge_conf_t, tuntap_ip6_mode),
+        .desc = "Define how the tuntap IPv6 address is set",
+        .help = "By default, the 'auto' mode allows the supernode to issue "
+                "an IPv6 address.  Other options are: 'static' - where the "
+                "address is statically configured; 'dhcp' - where no "
+                "address is set by the edge and an external process (or IPv6 "
+                "autoconfiguration) is expected to set it.",
     },
     {
         .name = "address_mode",

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -2906,8 +2906,13 @@ void process_pdu (struct n3n_runtime_data *eee,
                  * address - either it predates IPv6 support or its auto IPv6
                  * service is switched off. */
                 if(ra.dev_addr6.net_bitlen != 0) {
+                    ip6_bit_str_t ip6_bit_str = {'\0'};
+
                     memcpy(eee->conf.tuntap_v6.net_addr, ra.dev_addr6.net_addr, IPV6_SIZE);
                     eee->conf.tuntap_v6.net_bitlen = ra.dev_addr6.net_bitlen;
+
+                    traceEvent(TRACE_NORMAL, "supernode issued IPv6 address %s",
+                               ip6_subnet_to_str(ip6_bit_str, &eee->conf.tuntap_v6));
                 }
             }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -235,6 +235,23 @@ int edge_verify_conf (const n2n_edge_conf_t *conf) {
        ((conf->encrypt_key != NULL) && (conf->transop_id == N2N_TRANSFORM_ID_NULL)))
         return -4;
 
+    if((conf->tuntap_ip6_mode != TUNTAP_IP_MODE_DHCP) && (conf->mtu < IPV6_MIN_MTU)) {
+        /* Not fatal - the user may not care about IPv6 - but the kernel will
+         * refuse to keep an IPv6 address on an interface this small. */
+        traceEvent(TRACE_WARNING,
+                   "tuntap.mtu of %i is below the IPv6 minimum of %i, IPv6 will not work on the TAP interface",
+                   conf->mtu,
+                   IPV6_MIN_MTU);
+    }
+
+    if(!conf->allow_multicast &&
+       ((conf->tuntap_ip6_mode != TUNTAP_IP_MODE_DHCP) || (conf->tuntap_v6.net_bitlen != 0))) {
+        /* IPv6 neighbour discovery is multicast, so without this nothing on
+         * the IPv6 side will ever resolve a peer. */
+        traceEvent(TRACE_WARNING,
+                   "filter.allow_multicast is off, IPv6 neighbour discovery will be dropped and IPv6 will not work");
+    }
+
     return 0;
 }
 
@@ -1517,6 +1534,8 @@ void send_register_super (struct n3n_runtime_data *eee) {
     reg.cookie = eee->curr_sn->last_cookie;
     reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
     reg.dev_addr.net_bitlen = eee->conf.tuntap_v4.net_bitlen;
+    memcpy(reg.dev_addr6.net_addr, eee->device.ip6_addr, IPV6_SIZE);
+    reg.dev_addr6.net_bitlen = eee->device.ip6_bitlen;
     memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
     get_local_auth(eee, &(reg.auth));
 
@@ -1669,6 +1688,8 @@ static void send_register (struct n3n_runtime_data * eee,
     }
     reg.dev_addr.net_addr = ntohl(eee->device.ip_addr);
     reg.dev_addr.net_bitlen = eee->conf.tuntap_v4.net_bitlen;
+    memcpy(reg.dev_addr6.net_addr, eee->device.ip6_addr, IPV6_SIZE);
+    reg.dev_addr6.net_bitlen = eee->device.ip6_bitlen;
     memcpy(reg.dev_desc, eee->conf.dev_desc, N2N_DESC_SIZE);
 
     idx = 0;
@@ -2433,6 +2454,7 @@ void edge_read_from_tap (struct n3n_runtime_data * eee) {
                     eee->conf.tuntap_dev_name,
                     eee->conf.tuntap_ip_mode,
                     eee->conf.tuntap_v4,
+                    eee->conf.tuntap_v6,
                     eee->conf.device_mac,
                     eee->conf.mtu,
                     eee->conf.metric
@@ -2864,6 +2886,16 @@ void process_pdu (struct n3n_runtime_data *eee,
                 if((ra.dev_addr.net_addr != 0) && (ra.dev_addr.net_bitlen != 0)) {
                     eee->conf.tuntap_v4.net_addr = htonl(ra.dev_addr.net_addr);
                     eee->conf.tuntap_v4.net_bitlen = ra.dev_addr.net_bitlen;
+                }
+            }
+
+            if(eee->conf.tuntap_ip6_mode == TUNTAP_IP_MODE_SN_ASSIGN) {
+                /* A zero net_bitlen means the supernode did not issue an IPv6
+                 * address - either it predates IPv6 support or its auto IPv6
+                 * service is switched off. */
+                if(ra.dev_addr6.net_bitlen != 0) {
+                    memcpy(eee->conf.tuntap_v6.net_addr, ra.dev_addr6.net_addr, IPV6_SIZE);
+                    eee->conf.tuntap_v6.net_bitlen = ra.dev_addr6.net_bitlen;
                 }
             }
 
@@ -3623,6 +3655,10 @@ void edge_init_conf_defaults (n2n_edge_conf_t *conf, char *sessionname) {
     conf->tuntap_ip_mode = TUNTAP_IP_MODE_SN_ASSIGN;
     conf->tuntap_v4.net_bitlen = N2N_EDGE_DEFAULT_V4MASKLEN;
 
+    conf->tuntap_ip6_mode = TUNTAP_IP_MODE_SN_ASSIGN;
+    /* left all zero - the supernode fills this in, or the config overrides it */
+    memset(&conf->tuntap_v6, 0, sizeof(conf->tuntap_v6));
+
     /* reserve possible last char as null terminator. */
     gethostname((char*)conf->dev_desc, N2N_DESC_SIZE-1);
 
@@ -3684,9 +3720,13 @@ int quick_edge_init (char *device_name, char *community_name,
     subnet.net_addr = htonl(local_ip_address);
     subnet.net_bitlen = N2N_EDGE_DEFAULT_V4MASKLEN;
 
+    struct n2n_ip6_subnet subnet6;
+    memset(&subnet6, 0, sizeof(subnet6));   /* no IPv6 address */
+
     /* Open the tuntap device */
     if(tuntap_open(&tuntap, device_name, TUNTAP_IP_MODE_STATIC,
                    subnet,
+                   subnet6,
                    device_mac, conf.mtu,
                    0) < 0)
         return(-2);

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -446,6 +446,23 @@ void supernode_connect (struct n3n_runtime_data *eee) {
         return;
     }
 
+    /* Ask the socket itself rather than assuming the configured family: with
+     * no bind address open_socket() picks one, and may fall back to IPv4 when
+     * IPv6 is unavailable.  sendto_sock() needs the answer to hand the kernel
+     * a destination of the matching family. */
+    {
+        struct sockaddr_storage bound;
+        socklen_t bound_len = sizeof(bound);
+
+        if(getsockname(eee->sock, (struct sockaddr *)&bound, &bound_len) == 0) {
+            eee->sock_family = bound.ss_family;
+        } else {
+            traceEvent(TRACE_WARNING, "getsockname failed [%s], assuming IPv4",
+                       strerror(errno));
+            eee->sock_family = AF_INET;
+        }
+    }
+
     if(eee->conf.connect_tcp) {
         mainloop_register_fd(eee->sock, fd_info_proto_v3tcp);
     } else {
@@ -1346,19 +1363,14 @@ static void sendto_sock (struct n3n_runtime_data *eee, const void * buf,
 
     traceEvent(TRACE_DEBUG, "%s AF %i", __func__, dest->family);
 
-    // TODO: FIXME:
-    // This is a hack.  It was needed to successfully progress the test suite
-    // with the new IPv6 code, but I suspect it breaks things.
-    if(dest->family == AF_INET) {
-        sendto_fd(eee, buf, len, (struct sockaddr *) &peer_addr_storage, peer_addr_len);
-        return;
-    }
-
-    // this assumes we operate on a IPv6 dual stock socket
-    peer_addr_len = prepare_sockaddr_for_send(&dest_addr, AF_INET6, (const struct sockaddr *)&peer_addr_storage);
+    // Convert the destination to whichever family our socket actually is: an
+    // IPv6 socket needs IPv4 destinations as v4 mapped addresses, and an IPv4
+    // socket cannot be handed a sockaddr_in6 at all.
+    peer_addr_len = prepare_sockaddr_for_send(&dest_addr, eee->sock_family, (const struct sockaddr *)&peer_addr_storage);
     if(peer_addr_len == 0) {
-        // unknown or unsupported family we cannot send (unlikely after previous check though)
-        traceEvent(TRACE_DEBUG, "found unknown address family %d", peer_addr_storage.ss_family);
+        traceEvent(TRACE_WARNING,
+                   "cannot reach a family %d peer over a family %d socket",
+                   peer_addr_storage.ss_family, eee->sock_family);
         return;
     }
 

--- a/src/edge_utils.c
+++ b/src/edge_utils.c
@@ -323,14 +323,23 @@ void reset_sup_attempts (struct n3n_runtime_data *eee) {
 // error cases better
 static int detect_local_ip_address (n3n_sock_t* out_sock, const struct n3n_runtime_data* eee) {
 
-    struct sockaddr_in local_sock;
-    struct sockaddr_in sn_sock;
+    struct sockaddr_storage local_sock;
+    struct sockaddr_storage sn_sock_raw;
+    struct sockaddr_storage sn_sock;
     socklen_t sock_len;
+    socklen_t sn_sock_len;
     SOCKET probe_sock;
-    int ret = 0;
+    uint16_t local_port;
 
     memset(out_sock, 0, sizeof(*out_sock));
     out_sock->family = AF_INVALID;
+
+    if(!eee->curr_sn) {
+        // We dont have a current supernode, so we cannot use it to find our
+        // local address
+        // TODO: fall back to a different sample dest address?
+        return -5;
+    }
 
     // always detect local port even/especially if chosen by OS...
     sock_len = sizeof(local_sock);
@@ -338,30 +347,18 @@ static int detect_local_ip_address (n3n_sock_t* out_sock, const struct n3n_runti
         return -1;
     }
 
-    // TODO this whole function doesnt work with IPv6
-    if(local_sock.sin_family != AF_INET) {
-        traceEvent(TRACE_ERROR, "This function does only supports IPv4");
+    if(fill_n3nsock(out_sock, (struct sockaddr *)&local_sock) != 0) {
         return -1;
     }
 
-    if(sock_len != sizeof(local_sock)) {
-        return -1;
-    }
+    // remember the port number, the probe socket below gets its own
+    local_port = out_sock->port;
 
-    // remember the port number
-    out_sock->port = ntohs(local_sock.sin_port);
-
-    // probe for local IP address
-    probe_sock = socket(PF_INET, SOCK_DGRAM, 0);
-    if(probe_sock < 0) {
+    // probe for local IP address, using the same family as the socket we
+    // really communicate on
+    probe_sock = socket(local_sock.ss_family, SOCK_DGRAM, 0);
+    if((int)probe_sock < 0) {
         return -2;
-    }
-
-    if(!eee->curr_sn) {
-        // We dont have a current supernode, so we cannot use it to find our
-        // local address
-        // TODO: fall back to a different sample dest address?
-        return -5;
     }
 
     // connecting the UDP socket makes getsockname read the local address it
@@ -371,8 +368,23 @@ static int detect_local_ip_address (n3n_sock_t* out_sock, const struct n3n_runti
     // as re-connecting to AF_UNSPEC might not work to release the socket
     // on non-UNIXoids, we use a temporary socket
 
-    fill_sockaddr((struct sockaddr*)&sn_sock, sizeof(sn_sock), &eee->curr_sn->sock);
-    if(connect(probe_sock, (struct sockaddr *)&sn_sock, sizeof(sn_sock)) != 0) {
+    if(fill_sockaddr((struct sockaddr*)&sn_sock_raw, sizeof(sn_sock_raw), &eee->curr_sn->sock) == 0) {
+        closesocket(probe_sock);
+        return -3;
+    }
+
+    // an IPv6 probe socket needs an IPv4 supernode as a v4 mapped address
+    sn_sock_len = prepare_sockaddr_for_send(
+        &sn_sock,
+        local_sock.ss_family,
+        (const struct sockaddr *)&sn_sock_raw
+    );
+    if(sn_sock_len == 0) {
+        closesocket(probe_sock);
+        return -3;
+    }
+
+    if(connect(probe_sock, (struct sockaddr *)&sn_sock, sn_sock_len) != 0) {
         closesocket(probe_sock);
         return -3;
     }
@@ -383,23 +395,17 @@ static int detect_local_ip_address (n3n_sock_t* out_sock, const struct n3n_runti
         return -4;
     }
 
-    if(local_sock.sin_family != AF_INET) {
-        closesocket(probe_sock);
-        return -4;
-    }
-
-    if(sock_len != sizeof(local_sock)) {
-        closesocket(probe_sock);
-        return -4;
-    }
-
-    memcpy(&(out_sock->addr.v4), &(local_sock.sin_addr.s_addr), IPV4_SIZE);
-
     closesocket(probe_sock);
 
-    out_sock->family = AF_INET;
+    // fill_n3nsock() reports a v4 mapped address as plain AF_INET, so peers
+    // are told a directly usable address whichever family we ended up on
+    if(fill_n3nsock(out_sock, (struct sockaddr *)&local_sock) != 0) {
+        return -4;
+    }
 
-    return ret;
+    out_sock->port = local_port;
+
+    return 0;
 }
 
 

--- a/src/management.c
+++ b/src/management.c
@@ -537,6 +537,7 @@ static void jsonrpc_get_communities (char *id, struct n3n_runtime_data *eee, con
     // Otherwise send the supernode's view
     struct sn_community *community, *tmp;
     dec_ip_bit_str_t ip_bit_str = {'\0'};
+    ip6_bit_str_t ip6_bit_str = {'\0'};
 
     jsonrpc_result_head(id, conn);
     sb_reprintf(&conn->request, "[");
@@ -559,11 +560,13 @@ static void jsonrpc_get_communities (char *id, struct n3n_runtime_data *eee, con
                     "\"community\":\"%s\","
                     "\"purgeable\":%i,"
                     "\"is_federation\":%i,"
-                    "\"ip4addr\":\"%s\"},",
+                    "\"ip4addr\":\"%s\","
+                    "\"ip6addr\":\"%s\"},",
                     (community->is_federation) ? "-/-" : community->community,
                     community->purgeable,
                     community->is_federation,
-                    (community->auto_ip_net.net_addr == 0) ? "" : ip_subnet_to_str(ip_bit_str, &community->auto_ip_net));
+                    (community->auto_ip_net.net_addr == 0) ? "" : ip_subnet_to_str(ip_bit_str, &community->auto_ip_net),
+                    (community->auto_ip6_net.net_bitlen == 0) ? "" : ip6_subnet_to_str(ip6_bit_str, &community->auto_ip6_net));
 
         if(jsonrpc_error_overflow(id, conn, count)) {
             return;
@@ -583,12 +586,14 @@ static void jsonrpc_get_edges_row (strbuf_t **reply, struct peer_info *peer, con
     n3n_sock_str_t sockbuf;
     n3n_sock_str_t sockbuf2;
     dec_ip_bit_str_t ip_bit_str = {'\0'};
+    ip6_bit_str_t ip6_bit_str = {'\0'};
 
     sb_reprintf(reply,
                 "{"
                 "\"mode\":\"%s\","
                 "\"community\":\"%s\","
                 "\"ip4addr\":\"%s\","
+                "\"ip6addr\":\"%s\","
                 "\"purgeable\":%i,"
                 "\"local\":%i,"
                 "\"macaddr\":\"%s\","
@@ -605,6 +610,7 @@ static void jsonrpc_get_edges_row (strbuf_t **reply, struct peer_info *peer, con
                 mode,
                 community,
                 (peer->dev_addr.net_addr == 0) ? "" : ip_subnet_to_str(ip_bit_str, &peer->dev_addr),
+                (peer->dev_addr6.net_bitlen == 0) ? "" : ip6_subnet_to_str(ip6_bit_str, &peer->dev_addr6),
                 peer->purgeable,
                 peer->local,
                 (is_null_mac(peer->mac_addr)) ? "" : macaddr_str(mac_buf, peer->mac_addr),

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -57,14 +57,28 @@ SOCKET open_socket (struct sockaddr *local_address, socklen_t addrlen, int type 
     if(local_address) {
         family = local_address->sa_family;
     } else {
-        // If no bind details provided, assume IPv4.
-        family = AF_INET;
+        // No bind details provided, so open a dual stack IPv6 socket: with
+        // IPV6_V6ONLY cleared below it reaches IPv4 peers through v4 mapped
+        // addresses, whereas an IPv4 socket could not reach IPv6 peers at all.
+        family = AF_INET6;
     }
 
     if((int)(sock_fd = socket(family, ((type == 0) ? SOCK_DGRAM : SOCK_STREAM), 0)) < 0) {
-        traceEvent(TRACE_ERROR, "Unable to create socket for family %d [%s][%d]\n",
-                   family, strerror(errno), sock_fd);
-        return -1;
+        if(!local_address && (family == AF_INET6)) {
+            // IPv6 is unavailable (kernel built or booted without it), so the
+            // caller that expressed no preference still gets a usable socket.
+            traceEvent(TRACE_INFO,
+                       "No IPv6 socket available [%s], falling back to IPv4",
+                       strerror(errno));
+            family = AF_INET;
+            sock_fd = socket(family, ((type == 0) ? SOCK_DGRAM : SOCK_STREAM), 0);
+        }
+
+        if((int)sock_fd < 0) {
+            traceEvent(TRACE_ERROR, "Unable to create socket for family %d [%s][%d]\n",
+                       family, strerror(errno), sock_fd);
+            return -1;
+        }
     }
 
 #ifndef _WIN32

--- a/src/n2n.c
+++ b/src/n2n.c
@@ -358,6 +358,20 @@ char *ip_subnet_to_str (dec_ip_bit_str_t buf, const n2n_ip_subnet_t *ipaddr) {
 }
 
 // TODO: move to a strings helper source file
+char *ip6_subnet_to_str (ip6_bit_str_t buf, const n2n_ip6_subnet_t *ipaddr) {
+
+    if(inet_ntop(AF_INET6, ipaddr->net_addr, buf, sizeof(ip6_bit_str_t)) == NULL) {
+        snprintf(buf, sizeof(ip6_bit_str_t), "(invalid)");
+        return buf;
+    }
+
+    size_t used = strlen(buf);
+    snprintf(buf + used, sizeof(ip6_bit_str_t) - used, "/%u", ipaddr->net_bitlen);
+
+    return buf;
+}
+
+// TODO: move to a strings helper source file
 const char *sockaddr_to_str (char *s, size_t len, const struct sockaddr *sa) {
     if(sa->sa_family == AF_INET) {
         return inet_ntop(

--- a/src/peer_info.h
+++ b/src/peer_info.h
@@ -30,6 +30,7 @@ struct peer_info {
     bool purgeable;
     uint8_t local;
     n2n_ip_subnet_t dev_addr;
+    n2n_ip6_subnet_t dev_addr6;
     n2n_desc_t dev_desc;
     n3n_sock_t sock;
     SOCKET socket_fd;

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -615,11 +615,12 @@ static ssize_t sendto_sock (struct n3n_runtime_data *sss,
     socklen_t socket_len;
     struct sockaddr_storage dest_addr = {0};
 
-    // this assumes we operate on a IPv6 dual stock socket
-    socket_len = prepare_sockaddr_for_send(&dest_addr, AF_INET6, socket);
+    // Build a destination matching the family our socket was opened with
+    socket_len = prepare_sockaddr_for_send(&dest_addr, sss->sock_family, socket);
     if(socket_len == 0) {
-        // unknown or unsupported family we cannot send
-        traceEvent(TRACE_ERROR, "found unknown address family %d", socket->sa_family);
+        traceEvent(TRACE_ERROR,
+                   "cannot reach a family %d peer over a family %d socket",
+                   socket->sa_family, sss->sock_family);
         return -1;
     }
 

--- a/src/sn_utils.c
+++ b/src/sn_utils.c
@@ -259,7 +259,7 @@ void send_re_register_super (struct n3n_runtime_data *sss) {
  */
 int load_allowed_sn_community (struct n3n_runtime_data *sss) {
 
-    char buffer[4096], *line, *cmn_str, net_str[20], format[20];
+    char buffer[4096], *line, *cmn_str, net_str[20], net6_str[52], format[20];
 
     sn_user_t *user, *tmp_user;
     n2n_desc_t username;
@@ -267,7 +267,10 @@ int load_allowed_sn_community (struct n3n_runtime_data *sss) {
     char ascii_public_key[(N2N_PRIVATE_PUBLIC_KEY_SIZE * 8 + 5) / 6 + 1];
 
     dec_ip_str_t ip_str = {'\0'};
+    char ip6_str[46] = {'\0'};
     uint8_t bitlen;
+    uint8_t bitlen6;
+    uint8_t net6[IPV6_SIZE];
     in_addr_t net;
     uint32_t mask;
     FILE *fd = fopen(sss->conf.community_file, "r");
@@ -283,6 +286,7 @@ int load_allowed_sn_community (struct n3n_runtime_data *sss) {
     struct sn_community_regular_expression *re, *tmp_re;
     uint32_t num_regex = 0;
     int has_net;
+    int has_net6;
 
     if(fd == NULL) {
         traceEvent(TRACE_WARNING, "File %s not found", sss->conf.community_file);
@@ -413,7 +417,9 @@ int load_allowed_sn_community (struct n3n_runtime_data *sss) {
 
         // cut off any IP sub-network upfront
         cmn_str = (char*)calloc(len + 1, sizeof(char));
-        has_net = (sscanf(line, "%s %s", cmn_str, net_str) == 2);
+        int num_fields = sscanf(line, "%s %19s %51s", cmn_str, net_str, net6_str);
+        has_net = (num_fields >= 2);
+        has_net6 = (num_fields >= 3);
 
         // if it contains typical characters...
         if(NULL != strpbrk(cmn_str, ".*+?[]\\")) {
@@ -482,6 +488,39 @@ int load_allowed_sn_community (struct n3n_runtime_data *sss) {
                            comm->community);
             } else {
                 assign_one_ip_subnet(sss, comm);
+            }
+
+            // check for the optional IPv6 sub-network address
+            if(has_net6) {
+                if(sscanf(net6_str, "%45[^/]/%hhu", ip6_str, &bitlen6) != 2) {
+                    traceEvent(TRACE_WARNING, "bad net6/bit format '%s' for community '%s', ignoring; see comments inside community.list file",
+                               net6_str, cmn_str);
+                    has_net6 = 0;
+                } else if(inet_pton(AF_INET6, ip6_str, net6) != 1) {
+                    traceEvent(TRACE_WARNING, "bad IPv6 network '%s' in '%s' for community '%s', ignoring",
+                               ip6_str, net6_str, cmn_str);
+                    has_net6 = 0;
+                } else if(bitlen6 != N2N_SN_AUTO_IP6_HOST_BITLEN) {
+                    /* The host part always holds a 64 bit EUI-64, so anything
+                     * other than a /64 cannot be handed out. */
+                    traceEvent(TRACE_WARNING, "bad prefix '%hhu' in '%s' for community '%s', only /%u is supported, ignoring",
+                               bitlen6, net6_str, cmn_str, N2N_SN_AUTO_IP6_HOST_BITLEN);
+                    has_net6 = 0;
+                } else if(memcmp(net6 + 8, "\0\0\0\0\0\0\0\0", 8) != 0) {
+                    traceEvent(TRACE_WARNING, "IPv6 network '%s' for community '%s' has a non-zero host part, ignoring",
+                               net6_str, cmn_str);
+                    has_net6 = 0;
+                }
+            }
+            if(has_net6) {
+                ip6_bit_str_t ip6_bit_str = {'\0'};
+                memcpy(comm->auto_ip6_net.net_addr, net6, IPV6_SIZE);
+                comm->auto_ip6_net.net_bitlen = bitlen6;
+                traceEvent(TRACE_INFO, "assigned IPv6 sub-network %s to community '%s'",
+                           ip6_subnet_to_str(ip6_bit_str, &comm->auto_ip6_net),
+                           comm->community);
+            } else {
+                assign_one_ip6_subnet(sss, comm);
             }
         }
         free(cmn_str);
@@ -922,6 +961,8 @@ void sn_init_conf_defaults (struct n3n_runtime_data *sss, char *sessionname) {
     conf->sn_min_auto_ip_net.net_bitlen = N2N_SN_AUTO_IP_NET_BIT_DEFAULT;
     conf->sn_max_auto_ip_net.net_addr = inet_addr(N2N_SN_MAX_AUTO_IP_NET_DEFAULT);
     conf->sn_max_auto_ip_net.net_bitlen = N2N_SN_AUTO_IP_NET_BIT_DEFAULT;
+    inet_pton(AF_INET6, N2N_SN_AUTO_IP6_NET_DEFAULT, conf->sn_auto_ip6_net.net_addr);
+    conf->sn_auto_ip6_net.net_bitlen = N2N_SN_AUTO_IP6_NET_BIT_DEFAULT;
 
     sss->federation = (struct sn_community *)calloc(1, sizeof(struct sn_community));
     if(!sss->federation) {
@@ -1284,6 +1325,7 @@ static int update_edge (struct n3n_runtime_data *sss,
                 scan = peer_info_malloc(reg->edgeMac); /* deallocated in purge_expired_nodes */
                 scan->dev_addr.net_addr = reg->dev_addr.net_addr;
                 scan->dev_addr.net_bitlen = reg->dev_addr.net_bitlen;
+                memcpy(&(scan->dev_addr6), &(reg->dev_addr6), sizeof(n2n_ip6_subnet_t));
                 memcpy((char*)scan->dev_desc, reg->dev_desc, N2N_DESC_SIZE);
                 memcpy(&(scan->sock), sender_sock, sizeof(n3n_sock_t));
                 scan->socket_fd = socket_fd;
@@ -1323,6 +1365,7 @@ static int update_edge (struct n3n_runtime_data *sss,
             if(!sock_equal(sender_sock, &(scan->sock))) {
                 scan->dev_addr.net_addr = reg->dev_addr.net_addr;
                 scan->dev_addr.net_bitlen = reg->dev_addr.net_bitlen;
+                memcpy(&(scan->dev_addr6), &(reg->dev_addr6), sizeof(n2n_ip6_subnet_t));
                 memcpy((char*)scan->dev_desc, reg->dev_desc, N2N_DESC_SIZE);
                 memcpy(&(scan->sock), sender_sock, sizeof(n3n_sock_t));
                 scan->socket_fd = socket_fd;
@@ -1526,6 +1569,170 @@ int assign_one_ip_subnet (struct n3n_runtime_data *sss,
                    comm->community);
         return -1;
     }
+}
+
+
+/** Copy the leading bitlen bits of src into dst, leaving the rest of dst alone. */
+static void ip6_copy_prefix_bits (uint8_t *dst, const uint8_t *src, uint8_t bitlen) {
+
+    uint8_t whole = bitlen / 8;
+    uint8_t spare = bitlen % 8;
+
+    memcpy(dst, src, whole);
+
+    if(spare) {
+        uint8_t mask = (uint8_t)(0xFF << (8 - spare));
+        dst[whole] = (dst[whole] & ~mask) | (src[whole] & mask);
+    }
+}
+
+
+/** The IPv6 /64 assigned to the community by the auto ip address function of sn.
+ *
+ * The supernode prefix is typically much shorter than /64, so the bits between
+ * the end of that prefix and the /64 boundary are filled with a hash of the
+ * community name.  With at least 16 bits of community space this collides far
+ * more rarely than the IPv4 equivalent, and unlike IPv4 a collision is not
+ * fatal - the host part still separates the edges - so no scan is needed. */
+int assign_one_ip6_subnet (struct n3n_runtime_data *sss,
+                           struct sn_community *comm) {
+
+    const n2n_ip6_subnet_t *pool = &sss->conf.sn_auto_ip6_net;
+    ip6_bit_str_t ip6_bit_str = {'\0'};
+    uint8_t community_bits;
+    uint64_t hash;
+    uint8_t net[IPV6_SIZE];
+
+    memset(&comm->auto_ip6_net, 0, sizeof(comm->auto_ip6_net));
+
+    if(pool->net_bitlen == 0) {
+        /* The auto IPv6 service is switched off */
+        return -1;
+    }
+
+    if(pool->net_bitlen > N2N_SN_AUTO_IP6_HOST_BITLEN) {
+        traceEvent(TRACE_WARNING,
+                   "auto_ip6_net prefix /%u is longer than /%u, cannot assign an IPv6 sub-network to community '%s'",
+                   pool->net_bitlen,
+                   N2N_SN_AUTO_IP6_HOST_BITLEN,
+                   comm->community);
+        return -1;
+    }
+
+    memset(net, 0, sizeof(net));
+    ip6_copy_prefix_bits(net, pool->net_addr, pool->net_bitlen);
+
+    /* Spread the community hash across the bits between the configured prefix
+     * and the /64 boundary. */
+    community_bits = N2N_SN_AUTO_IP6_HOST_BITLEN - pool->net_bitlen;
+    if(community_bits) {
+        hash = pearson_hash_64((const uint8_t *)comm->community, N2N_COMMUNITY_SIZE);
+        /* Keeping only the low community_bits bits of the hash lands it in
+         * exactly the bit range [net_bitlen, 64) once written big endian into
+         * the leading 8 bytes, which is the gap between the pool prefix and
+         * the /64 boundary. */
+        hash &= (UINT64_C(1) << community_bits) - 1;
+
+        for(int i = 0; i < 8; i++) {
+            net[i] |= (uint8_t)(hash >> (56 - 8 * i));
+        }
+    }
+
+    memcpy(comm->auto_ip6_net.net_addr, net, IPV6_SIZE);
+    comm->auto_ip6_net.net_bitlen = N2N_SN_AUTO_IP6_HOST_BITLEN;
+
+    traceEvent(TRACE_INFO, "assigned IPv6 sub-network %s to community '%s'",
+               ip6_subnet_to_str(ip6_bit_str, &comm->auto_ip6_net),
+               comm->community);
+
+    return 0;
+}
+
+
+/** checks if a certain IPv6 address is still available in a community */
+static int ip6_addr_available (struct sn_community *comm, const n2n_ip6_subnet_t *ip6_addr) {
+
+    struct peer_info *peer, *tmp_peer;
+
+    HASH_ITER(hh, comm->edges, peer, tmp_peer) {
+        if(peer->dev_addr6.net_bitlen == 0) {
+            continue;
+        }
+        if(memcmp(peer->dev_addr6.net_addr, ip6_addr->net_addr, IPV6_SIZE) == 0) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+
+/** Write a 64 bit host part into the low half of an address. */
+static void ip6_set_host_part (uint8_t *net_addr, uint64_t host) {
+
+    for(int i = 0; i < 8; i++) {
+        net_addr[8 + i] = (uint8_t)(host >> (56 - 8 * i));
+    }
+}
+
+
+/** The IPv6 address assigned to the edge by the auto ip address function of sn.
+ *
+ * The host part is derived from the edge description rather than from its MAC
+ * address: the edge asks for an address during bootstrap, before it has opened
+ * its TAP interface, so at that point the MAC it reports is still all zeroes
+ * and would be identical for every edge.  This is the same input the IPv4 path
+ * hashes, which also keeps the two addresses of an edge consistent with each
+ * other.
+ *
+ * With 64 host bits a hash collision is unlikely, but two edges sharing a
+ * description (the hostname by default) hash to the same value, so the result
+ * is still checked against the community and probed upwards if taken. */
+static int assign_one_ip6_addr (struct sn_community *comm,
+                                n2n_desc_t dev_desc,
+                                n2n_ip6_subnet_t *ip6_addr) {
+
+    ip6_bit_str_t ip6_bit_str = {'\0'};
+    uint64_t host;
+
+    memset(ip6_addr, 0, sizeof(*ip6_addr));
+
+    if(comm->auto_ip6_net.net_bitlen == 0) {
+        /* No IPv6 sub-network for this community */
+        return -1;
+    }
+
+    memcpy(ip6_addr->net_addr, comm->auto_ip6_net.net_addr, IPV6_SIZE);
+    ip6_addr->net_bitlen = comm->auto_ip6_net.net_bitlen;
+
+    host = pearson_hash_64(dev_desc, sizeof(n2n_desc_t));
+
+    /* Clear the universal/local bit: this identifier is made up locally and is
+     * not derived from a globally unique EUI-64. */
+    host &= ~(UINT64_C(0x02) << 56);
+
+    for(int attempt = 0; attempt < 16; attempt++) {
+        /* The all zero host part is the subnet router anycast address, and the
+         * top of the range is reserved for anycast too (RFC 2526). */
+        if((host == 0) || (host >= UINT64_C(0xFFFFFFFFFFFFFF80))) {
+            host = 1;
+        }
+
+        ip6_set_host_part(ip6_addr->net_addr, host);
+
+        if(ip6_addr_available(comm, ip6_addr)) {
+            traceEvent(TRACE_INFO, "assign IPv6 %s to tap adapter of edge",
+                       ip6_subnet_to_str(ip6_bit_str, ip6_addr));
+            return 0;
+        }
+
+        host++;
+    }
+
+    traceEvent(TRACE_WARNING, "no assignable IPv6 address to edge tap adapter");
+    memset(ip6_addr, 0, sizeof(*ip6_addr));
+
+    return -1;
 }
 
 
@@ -2124,6 +2331,7 @@ static int process_pdu (struct n3n_runtime_data * sss,
 
                     traceEvent(TRACE_INFO, "new community: %s", comm->community);
                     assign_one_ip_subnet(sss, comm);
+                    assign_one_ip6_subnet(sss, comm);
                 }
             }
 
@@ -2169,6 +2377,14 @@ static int process_pdu (struct n3n_runtime_data * sss,
                     assign_one_ip_addr(comm, reg.dev_desc, &ipaddr);
                     ack.dev_addr.net_addr = ipaddr.net_addr;
                     ack.dev_addr.net_bitlen = ipaddr.net_bitlen;
+                }
+
+                /* Same idea for IPv6: only hand out an address when the edge
+                 * did not bring one of its own.  A link local address does not
+                 * count as configured, it is what the OS makes up by itself. */
+                if((reg.dev_addr6.net_bitlen == 0) ||
+                   ((reg.dev_addr6.net_addr[0] == 0xFE) && ((reg.dev_addr6.net_addr[1] & 0xC0) == 0x80))) {
+                    assign_one_ip6_addr(comm, reg.dev_desc, &ack.dev_addr6);
                 }
             }
 

--- a/src/tuntap_freebsd.c
+++ b/src/tuntap_freebsd.c
@@ -37,6 +37,7 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *dev,
                  uint8_t address_mode, /* unused! */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac,
                  int mtu,
                  int ignored) {
@@ -85,6 +86,30 @@ int tuntap_open (tuntap_dev *device /* ignored */,
         system(buf);
 
         traceEvent(TRACE_NORMAL, "Interface tap%d up and running (%s/%u)", i, addr_buf, v4subnet.net_bitlen);
+
+        /* The IPv6 address is added separately, the interface keeps both */
+        if(v6subnet.net_bitlen) {
+            char addr6_buf[INET6_ADDRSTRLEN];
+
+            if(inet_ntop(AF_INET6, v6subnet.net_addr, addr6_buf, sizeof(addr6_buf)) == NULL) {
+                traceEvent(TRACE_ERROR, "Unable to format the IPv6 address for tap%d", i);
+            } else {
+                snprintf(buf, sizeof(buf), "ifconfig tap%d inet6 %s prefixlen %u up",
+                         i,
+                         addr6_buf,
+                         v6subnet.net_bitlen
+                );
+                if(system(buf) != 0) {
+                    traceEvent(TRACE_ERROR, "Unable to set IPv6 address %s/%u on tap%d",
+                               addr6_buf, v6subnet.net_bitlen, i);
+                } else {
+                    memcpy(device->ip6_addr, v6subnet.net_addr, sizeof(device->ip6_addr));
+                    device->ip6_bitlen = v6subnet.net_bitlen;
+                    traceEvent(TRACE_NORMAL, "Interface tap%d IPv6 %s/%u",
+                               i, addr6_buf, v6subnet.net_bitlen);
+                }
+            }
+        }
 
         // read MAC address
         snprintf(buf, sizeof(buf), "ifconfig tap%d |grep ether|cut -c 8-24", i);

--- a/src/tuntap_freebsd.c
+++ b/src/tuntap_freebsd.c
@@ -72,7 +72,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
             system(buf);
         }
 
-        in_addr_t addr = htonl(device->ip_addr);
+        // ip_addr is already in network order, unlike the bitlen2mask() result
+        in_addr_t addr = device->ip_addr;
         in_addr_t mask = htonl(bitlen2mask(v4subnet.net_bitlen));
         char addr_buf[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &addr, &addr_buf, sizeof(addr_buf));

--- a/src/tuntap_linux.c
+++ b/src/tuntap_linux.c
@@ -45,6 +45,7 @@
 #include "n2n.h"                      // for tuntap_dev, ...
 #include "n2n_typedefs.h"
 #include "n3n/ethernet.h"
+#include "n3n/strings.h"              // for ip6_subnet_to_str
 
 
 static int setup_ifname (int fd, const char *ifname,
@@ -108,6 +109,74 @@ static int setup_ifname (int fd, const char *ifname,
 }
 
 
+/* The kernel takes IPv6 interface addresses through SIOCSIFADDR on an AF_INET6
+ * socket with this structure, not through the AF_INET struct ifreq used above.
+ * It lives in <linux/ipv6.h>, which cannot be included alongside
+ * <netinet/in.h> without clashing, so it is declared here instead. */
+struct n3n_in6_ifreq {
+    struct in6_addr ifr6_addr;
+    uint32_t ifr6_prefixlen;
+    int ifr6_ifindex;
+};
+
+
+/** @brief Add an IPv6 address to an already configured interface.
+ *
+ *  @return - 0 on success, negative on error
+ */
+static int setup_ifname_v6 (const char *ifname, struct n2n_ip6_subnet v6subnet) {
+
+    struct n3n_in6_ifreq ifr6;
+    struct ifreq ifr;
+    ip6_bit_str_t ip6_bit_str = {'\0'};
+    int fd;
+
+    if(v6subnet.net_bitlen == 0) {
+        /* No IPv6 address to set */
+        return 0;
+    }
+
+    if((fd = socket(AF_INET6, SOCK_DGRAM, IPPROTO_IP)) < 0) {
+        traceEvent(TRACE_ERROR, "IPv6 socket creation failed [%d]: %s", errno, strerror(errno));
+        return -1;
+    }
+
+    /* The in6_ifreq refers to the interface by index, not by name */
+    memset(&ifr, 0, sizeof(ifr));
+    strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
+    ifr.ifr_name[IFNAMSIZ-1] = '\0';
+
+    if(ioctl(fd, SIOCGIFINDEX, &ifr) == -1) {
+        traceEvent(TRACE_ERROR, "ioctl(SIOCGIFINDEX) failed [%d]: %s", errno, strerror(errno));
+        close(fd);
+        return -2;
+    }
+
+    memset(&ifr6, 0, sizeof(ifr6));
+    memcpy(&ifr6.ifr6_addr, v6subnet.net_addr, sizeof(ifr6.ifr6_addr));
+    ifr6.ifr6_prefixlen = v6subnet.net_bitlen;
+    ifr6.ifr6_ifindex = ifr.ifr_ifindex;
+
+    if(ioctl(fd, SIOCSIFADDR, &ifr6) == -1) {
+        /* EEXIST simply means we already have this address, which is not worth
+         * failing the interface setup over. */
+        if(errno != EEXIST) {
+            traceEvent(TRACE_ERROR, "ioctl(SIOCSIFADDR, %s) failed [%d]: %s",
+                       ip6_subnet_to_str(ip6_bit_str, &v6subnet), errno, strerror(errno));
+            close(fd);
+            return -3;
+        }
+    }
+
+    close(fd);
+
+    traceEvent(TRACE_INFO, "assigned IPv6 address %s to %s",
+               ip6_subnet_to_str(ip6_bit_str, &v6subnet), ifname);
+
+    return 0;
+}
+
+
 /** @brief  Open and configure the TAP device for packet read/write.
  *
  *  This routine creates the interface via the tuntap driver and then
@@ -117,6 +186,7 @@ static int setup_ifname (int fd, const char *ifname,
  *  @param dev         - user-defined name for the new iface,
  *                       if NULL system will assign a name
  *  @param v4subnet    - address and netmask of iface
+ *  @param v6subnet    - IPv6 address and prefix length, zero bitlen for none
  *  @param mtu         - MTU for device
  *
  *  @return - negative value on error
@@ -126,6 +196,7 @@ int tuntap_open (tuntap_dev *device,
                  char *dev, /* user-definable interface name, eg. edge0 */
                  uint8_t address_mode, /* unused! */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac,
                  int mtu,
                  int ignored) {
@@ -254,6 +325,13 @@ int tuntap_open (tuntap_dev *device,
     close(nl_fd);
 
     device->ip_addr = v4subnet.net_addr;
+
+    /* The IPv6 address has to go on after the interface is up, otherwise the
+     * kernel discards it again when duplicate address detection restarts. */
+    if(setup_ifname_v6(device->dev_name, v6subnet) == 0) {
+        memcpy(device->ip6_addr, v6subnet.net_addr, sizeof(device->ip6_addr));
+        device->ip6_bitlen = v6subnet.net_bitlen;
+    }
 
     return device->fd;
 }

--- a/src/tuntap_netbsd.c
+++ b/src/tuntap_netbsd.c
@@ -43,6 +43,7 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *dev,
                  uint8_t address_mode, /* unused! */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac,
                  int mtu,
                  int ignored) {
@@ -98,6 +99,30 @@ int tuntap_open (tuntap_dev *device /* ignored */,
         system(cmd);
 
         traceEvent(TRACE_NORMAL, "Interface %s up and running (%s/%u)", tap_device, addr_buf, v4subnet.net_bitlen);
+
+        /* The IPv6 address is added separately, the interface keeps both */
+        if(v6subnet.net_bitlen) {
+            char addr6_buf[INET6_ADDRSTRLEN];
+
+            if(inet_ntop(AF_INET6, v6subnet.net_addr, addr6_buf, sizeof(addr6_buf)) == NULL) {
+                traceEvent(TRACE_ERROR, "Unable to format the IPv6 address for %s", tap_device);
+            } else {
+                snprintf(cmd, sizeof(cmd), "ifconfig %s inet6 %s prefixlen %u up",
+                         tap_device,
+                         addr6_buf,
+                         v6subnet.net_bitlen
+                );
+                if(system(cmd) != 0) {
+                    traceEvent(TRACE_ERROR, "Unable to set IPv6 address %s/%u on %s",
+                               addr6_buf, v6subnet.net_bitlen, tap_device);
+                } else {
+                    memcpy(device->ip6_addr, v6subnet.net_addr, sizeof(device->ip6_addr));
+                    device->ip6_bitlen = v6subnet.net_bitlen;
+                    traceEvent(TRACE_NORMAL, "Interface %s IPv6 %s/%u",
+                               tap_device, addr6_buf, v6subnet.net_bitlen);
+                }
+            }
+        }
 
         // read MAC address
         snprintf(cmd, sizeof(cmd), "ifconfig %s |grep address|cut -c 11-28", tap_device);

--- a/src/tuntap_netbsd.c
+++ b/src/tuntap_netbsd.c
@@ -85,7 +85,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
             system(cmd);
         }
 
-        in_addr_t addr = htonl(device->ip_addr);
+        // ip_addr is already in network order, unlike the bitlen2mask() result
+        in_addr_t addr = device->ip_addr;
         in_addr_t mask = htonl(bitlen2mask(v4subnet.net_bitlen));
         char addr_buf[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &addr, &addr_buf, sizeof(addr_buf));

--- a/src/tuntap_osx.c
+++ b/src/tuntap_osx.c
@@ -73,7 +73,8 @@ int tuntap_open (tuntap_dev *device /* ignored */,
             system(buf);
         }
 
-        in_addr_t addr = htonl(device->ip_addr);
+        // ip_addr is already in network order, unlike the bitlen2mask() result
+        in_addr_t addr = device->ip_addr;
         in_addr_t mask = htonl(bitlen2mask(v4subnet.net_bitlen));
         char addr_buf[INET_ADDRSTRLEN];
         inet_ntop(AF_INET, &addr, &addr_buf, sizeof(addr_buf));

--- a/src/tuntap_osx.c
+++ b/src/tuntap_osx.c
@@ -38,6 +38,7 @@ int tuntap_open (tuntap_dev *device /* ignored */,
                  char *dev,
                  uint8_t address_mode, /* unused! */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac,
                  int mtu,
                  int ignored) {
@@ -86,6 +87,30 @@ int tuntap_open (tuntap_dev *device /* ignored */,
         system(buf);
 
         traceEvent(TRACE_NORMAL, "Interface tap%d up and running (%s/%u)", i, addr_buf, v4subnet.net_bitlen);
+
+        /* The IPv6 address is added separately, the interface keeps both */
+        if(v6subnet.net_bitlen) {
+            char addr6_buf[INET6_ADDRSTRLEN];
+
+            if(inet_ntop(AF_INET6, v6subnet.net_addr, addr6_buf, sizeof(addr6_buf)) == NULL) {
+                traceEvent(TRACE_ERROR, "Unable to format the IPv6 address for tap%d", i);
+            } else {
+                snprintf(buf, sizeof(buf), "ifconfig tap%d inet6 %s prefixlen %u up",
+                         i,
+                         addr6_buf,
+                         v6subnet.net_bitlen
+                );
+                if(system(buf) != 0) {
+                    traceEvent(TRACE_ERROR, "Unable to set IPv6 address %s/%u on tap%d",
+                               addr6_buf, v6subnet.net_bitlen, i);
+                } else {
+                    memcpy(device->ip6_addr, v6subnet.net_addr, sizeof(device->ip6_addr));
+                    device->ip6_bitlen = v6subnet.net_bitlen;
+                    traceEvent(TRACE_NORMAL, "Interface tap%d IPv6 %s/%u",
+                               i, addr6_buf, v6subnet.net_bitlen);
+                }
+            }
+        }
 
         // read MAC address
         snprintf(buf, sizeof(buf), "ifconfig tap%d |grep ether|cut -c 8-24", i);

--- a/src/win32/wintap.c
+++ b/src/win32/wintap.c
@@ -212,6 +212,7 @@ int open_wintap (struct tuntap_dev *device,
                  const char * devname,
                  uint8_t address_mode, /* "static" or "dhcp" */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char *device_mac,
                  int mtu,
                  int metric) {
@@ -334,6 +335,34 @@ int open_wintap (struct tuntap_dev *device,
     } else {
         printf("ERROR: Unable to set IP address [%s]\n", cmd);
         return -1;
+    }
+
+    /* ****************** */
+
+    /* IPv6 address, if we have one to set */
+
+    if(v6subnet.net_bitlen) {
+        char addr6_buf[INET6_ADDRSTRLEN];
+
+        if(inet_ntop(AF_INET6, v6subnet.net_addr, (char *)&addr6_buf, sizeof(addr6_buf)) == NULL) {
+            printf("ERROR: Unable to format the IPv6 address\n");
+        } else {
+            /* 'set address' would replace any existing address, but IPv6
+             * interfaces normally keep their link local one, so add instead */
+            _snprintf(cmd, sizeof(cmd),
+                      "netsh interface ipv6 add address \"%s\" %s/%u > nul",
+                      device->ifName,
+                      addr6_buf,
+                      v6subnet.net_bitlen
+            );
+
+            if(system(cmd) == 0) {
+                memcpy(device->ip6_addr, v6subnet.net_addr, sizeof(device->ip6_addr));
+                device->ip6_bitlen = v6subnet.net_bitlen;
+            } else {
+                printf("WARNING: Unable to set IPv6 address [%s]\n", cmd);
+            }
+        }
     }
 
     /* ****************** */
@@ -513,10 +542,11 @@ int tuntap_open (struct tuntap_dev *device,
                  char *dev,
                  uint8_t address_mode, /* static or dhcp */
                  struct n2n_ip_subnet v4subnet,
+                 struct n2n_ip6_subnet v6subnet,
                  const char * device_mac,
                  int mtu,
                  int metric) {
-    return(open_wintap(device, dev, address_mode, v4subnet, device_mac, mtu, metric));
+    return(open_wintap(device, dev, address_mode, v4subnet, v6subnet, device_mac, mtu, metric));
 }
 
 /* ************************************************ */

--- a/src/wire.c
+++ b/src/wire.c
@@ -204,6 +204,46 @@ static int decode_mac (n2n_mac_t out,
     return decode_buf(out, N2N_MAC_SIZE, base, rem, idx);
 }
 
+/* The IPv6 subnet fields are always encoded at the very end of their message
+ * so that they are optional on the wire: a peer built before IPv6 support
+ * simply stops decoding early, and decode_ip6_subnet() leaves the (memset to
+ * zero) destination alone when the bytes are not present.  A zero net_bitlen
+ * therefore means "the other side did not send an IPv6 subnet". */
+static int encode_ip6_subnet (uint8_t * base,
+                              size_t * idx,
+                              const n2n_ip6_subnet_t * s) {
+
+    int retval = 0;
+
+    retval += encode_buf(base, idx, s->net_addr, IPV6_SIZE);
+    retval += encode_uint8(base, idx, s->net_bitlen);
+
+    return retval;
+}
+
+static int decode_ip6_subnet (n2n_ip6_subnet_t * s,
+                              const uint8_t * base,
+                              size_t * rem,
+                              size_t * idx) {
+
+    int retval = 0;
+
+    /* Decode all of the subnet or none of it.  This must stay atomic: the
+     * REGISTER_SUPER and REGISTER_SUPER_ACK messages may carry a trailing
+     * N2N_REG_SUP_HASH_CHECK_LEN byte hash which is still counted in *rem, so
+     * a peer that sent no IPv6 subnet can leave exactly that many bytes
+     * unconsumed here.  Requiring the full IPV6_SIZE + 1 bytes keeps those
+     * hash bytes from being mistaken for an address. */
+    if(*rem < IPV6_SIZE + 1) {
+        return 0;
+    }
+
+    retval += decode_buf(s->net_addr, IPV6_SIZE, base, rem, idx);
+    retval += decode_uint8(&(s->net_bitlen), base, rem, idx);
+
+    return retval;
+}
+
 static int encode_cookie (uint8_t * base,
                           size_t * idx,
                           const n2n_cookie_t c) {
@@ -397,6 +437,7 @@ int encode_REGISTER (uint8_t *base,
     retval += encode_uint32(base, idx, reg->dev_addr.net_addr);
     retval += encode_uint8(base, idx, reg->dev_addr.net_bitlen);
     retval += encode_buf(base, idx, reg->dev_desc, N2N_DESC_SIZE);
+    retval += encode_ip6_subnet(base, idx, &(reg->dev_addr6));
 
     return retval;
 }
@@ -420,6 +461,7 @@ int decode_REGISTER (n2n_REGISTER_t *reg,
     retval += decode_uint32(&(reg->dev_addr.net_addr), base, rem, idx);
     retval += decode_uint8(&(reg->dev_addr.net_bitlen), base, rem, idx);
     retval += decode_buf(reg->dev_desc, N2N_DESC_SIZE, base, rem, idx);
+    retval += decode_ip6_subnet(&(reg->dev_addr6), base, rem, idx);
 
     return retval;
 }
@@ -445,6 +487,7 @@ int encode_REGISTER_SUPER (uint8_t *base,
     retval += encode_uint16(base, idx, reg->auth.token_size);
     retval += encode_buf(base, idx, reg->auth.token, reg->auth.token_size);
     retval += encode_uint32(base, idx, reg->key_time);
+    retval += encode_ip6_subnet(base, idx, &(reg->dev_addr6));
 
     return retval;
 }
@@ -476,6 +519,7 @@ int decode_REGISTER_SUPER (n2n_REGISTER_SUPER_t *reg,
     }
     retval += decode_buf(reg->auth.token, reg->auth.token_size, base, rem, idx);
     retval += decode_uint32(&(reg->key_time), base, rem, idx);
+    retval += decode_ip6_subnet(&(reg->dev_addr6), base, rem, idx);
 
     return retval;
 }

--- a/src/wire.c
+++ b/src/wire.c
@@ -637,6 +637,7 @@ int encode_REGISTER_SUPER_ACK (uint8_t *base,
     retval += encode_buf(base, idx, tmpbuf, (reg->num_sn*REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE));
 
     retval += encode_uint32(base, idx, reg->key_time);
+    retval += encode_ip6_subnet(base, idx, &(reg->dev_addr6));
 
     return retval;
 }
@@ -680,6 +681,7 @@ int decode_REGISTER_SUPER_ACK (n2n_REGISTER_SUPER_ACK_t *reg,
     retval += decode_buf(tmpbuf, (reg->num_sn * REG_SUPER_ACK_PAYLOAD_ENTRY_SIZE), base, rem, idx);
 
     retval += decode_uint32(&(reg->key_time), base, rem, idx);
+    retval += decode_ip6_subnet(&(reg->dev_addr6), base, rem, idx);
 
     return retval;
 }

--- a/tests/test_builtin_edge.sh.expected
+++ b/tests/test_builtin_edge.sh.expected
@@ -38,6 +38,7 @@ port=0
 unix_sock_perms=0
 
 [supernode]
+auto_ip6_net=::/0
 auto_ip_max=0.0.0.0/0
 auto_ip_min=0.0.0.0/0
 macaddr=00:00:00:00:00:00
@@ -51,6 +52,8 @@ output_format=pretty
 
 [tuntap]
 address=0.0.0.0/0
+address6=::/0
+address6_mode=auto
 address_mode=auto
 metric=0
 mtu=0

--- a/tests/tests-wire.expected
+++ b/tests/tests-wire.expected
@@ -49,6 +49,12 @@ REGISTER_SUPER_no_ip6: truncated_plus_hash: key_time = 600
 REGISTER_SUPER_no_ip6: truncated_plus_hash: dev_addr6 = ::/0
 REGISTER_SUPER_no_ip6: truncated_plus_hash: unconsumed bytes = 16
 
+REGISTER_SUPER_ACK_ip6: in  ack.dev_addr6 = fd11:2233:4455:6677:8899:aabb:ccdd:eeff/64
+REGISTER_SUPER_ACK_ip6: encoded size = 0x67
+REGISTER_SUPER_ACK_ip6: out ack.dev_addr6 = fd11:2233:4455:6677:8899:aabb:ccdd:eeff/64
+REGISTER_SUPER_ACK_ip6: unconsumed bytes = 0
+REGISTER_SUPER_ACK_ip6: dev_addr6 survived = yes
+
 UNREGISTER_SUPER: common.pc = 6
 UNREGISTER_SUPER: unreg.auth.scheme = 1
 UNREGISTER_SUPER: unreg.auth.token_size = 16
@@ -168,7 +174,8 @@ pktbuf:
 030: 36 44 43 00 10 47 48 49  4a 4b 4c 4d 4e 4f 50 51   |6DC  GHIJKLMNOPQ|
 040: 52 53 54 55 56 01 02 00  93 94 95 96 97 98 00 00   |RSTUV           |
 050: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
-060: 7c 7b 7a 79                                        ||{zy|
+060: 7c 7b 7a 79 7d 7e 7f 80  81 82 83 84 85 86 87 88   ||{zy}~          |
+070: 89 8a 8b 8c 8d                                     |     |
 out_common:
 000: 01 02 00 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10   |                |
 010: 11 12 13 14 15 16 17 18                            |        |
@@ -179,8 +186,8 @@ out_data:
 030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54 55 56 00 00   |IJKLMNOPQRSTUV  |
 040: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
 050: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 01 00   |                |
-060: 79 7a 7b 7c 00 00 00 00  00 00 00 00 00 00 00 00   |yz{|            |
-070: 00 00 00 00 00 00 00 00                            |        |
+060: 79 7a 7b 7c 7d 7e 7f 80  81 82 83 84 85 86 87 88   |yz{|}~          |
+070: 89 8a 8b 8c 8d 00 00 00                            |        |
 out_tmpbuf:
 000: 02 00 93 94 95 96 97 98  00 00 00 00 00 00 00 00   |                |
 010: 00 00 00 00 00 00 00 00  00 00                     |          |

--- a/tests/tests-wire.expected
+++ b/tests/tests-wire.expected
@@ -9,13 +9,15 @@ REGISTER: reg.dstMac[] = 10:11:12:13:14:15
 REGISTER: reg.dev_addr.net_addr = 0x20212223
 REGISTER: reg.dev_addr.net_bitlen = 25
 REGISTER: reg.dev_desc = "Dummy_Dev_Desc"
+REGISTER: reg.dev_addr6 = fd11:2233:4455:6677:8899:aabb:ccdd:eeff/64
 
-REGISTER: output retval = 0x24
-REGISTER: output idx = 0x3d
+REGISTER: output retval = 0x35
+REGISTER: output idx = 0x4e
 000: 03 02 00 01 61 62 63 31  32 33 64 65 66 34 35 36   |    abc123def456|
 010: 7a 00 00 00 00 00 00 00  00 00 00 00 00 01 02 03   |z               |
 020: 04 05 10 11 12 13 14 15  20 21 22 23 19 44 75 6d   |         !"# Dum|
-030: 6d 79 5f 44 65 76 5f 44  65 73 63 00 00            |my_Dev_Desc  |
+030: 6d 79 5f 44 65 76 5f 44  65 73 63 00 00 fd 11 22   |my_Dev_Desc    "|
+040: 33 44 55 66 77 88 99 aa  bb cc dd ee ff 40         |3DUfw        @|
 
 REGISTER_SUPER: common.pc = 5
 REGISTER_SUPER: reg.cookie = 0
@@ -27,14 +29,25 @@ REGISTER_SUPER: reg.auth.scheme = 1
 REGISTER_SUPER: reg.auth.token_size = 16
 REGISTER_SUPER: reg.auth.token[0] = 0xfe
 REGISTER_SUPER: reg.key_time = 600
+REGISTER_SUPER: reg.dev_addr6 = fd11:2233:4455:6677:8899:aabb:ccdd:eeff/64
 
-REGISTER_SUPER: output retval = 0x36
-REGISTER_SUPER: output idx = 0x4f
+REGISTER_SUPER: output retval = 0x47
+REGISTER_SUPER: output idx = 0x60
 000: 03 02 00 05 61 62 63 31  32 33 64 65 66 34 35 36   |    abc123def456|
 010: 7a 00 00 00 00 00 00 00  00 00 00 00 20 21 22 23   |z            !"#|
 020: 24 25 20 21 22 23 19 44  75 6d 6d 79 5f 44 65 76   |$% !"# Dummy_Dev|
 030: 5f 44 65 73 63 00 00 00  01 00 10 fe 00 00 00 fd   |_Desc           |
-040: 00 00 00 fc 00 00 00 00  00 00 fb 00 00 02 58      |              X|
+040: 00 00 00 fc 00 00 00 00  00 00 fb 00 00 02 58 fd   |              X |
+050: 11 22 33 44 55 66 77 88  99 aa bb cc dd ee ff 40   | "3DUfw        @|
+
+REGISTER_SUPER_no_ip6: truncated: dev_addr.net_addr = 0x20212223
+REGISTER_SUPER_no_ip6: truncated: key_time = 600
+REGISTER_SUPER_no_ip6: truncated: dev_addr6 = ::/0
+REGISTER_SUPER_no_ip6: truncated: unconsumed bytes = 0
+REGISTER_SUPER_no_ip6: truncated_plus_hash: dev_addr.net_addr = 0x20212223
+REGISTER_SUPER_no_ip6: truncated_plus_hash: key_time = 600
+REGISTER_SUPER_no_ip6: truncated_plus_hash: dev_addr6 = ::/0
+REGISTER_SUPER_no_ip6: truncated_plus_hash: unconsumed bytes = 16
 
 UNREGISTER_SUPER: common.pc = 6
 UNREGISTER_SUPER: unreg.auth.scheme = 1
@@ -54,7 +67,8 @@ pktbuf:
 000: 03 01 04 02 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10   |                |
 010: 11 12 13 14 15 16 17 18  1c 1b 1a 19 1d 1e 1f 20   |                |
 020: 21 22 23 24 25 26 27 28  40 3f 3e 3d 41 45 46 47   |!"#$%&'(@?>=AEFG|
-030: 48 49 4a 4b 4c 4d 4e 4f  50 51 52 53 54            |HIJKLMNOPQRST|
+030: 48 49 4a 4b 4c 4d 4e 4f  50 51 52 53 54 55 56 57   |HIJKLMNOPQRSTUVW|
+040: 58 59 5a 5b 5c 5d 5e 5f  60 61 62 63 64 65         |XYZ[\]^_`abcde|
 out_common:
 000: 01 02 00 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10   |                |
 010: 11 12 13 14 15 16 17 18                            |        |
@@ -62,7 +76,8 @@ out_data:
 000: 19 1a 1b 1c 1d 1e 1f 20  21 22 23 24 25 26 27 28   |        !"#$%&'(|
 010: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
 020: 00 00 00 00 3d 3e 3f 40  41 00 00 00 45 46 47 48   |    =>?@A   EFGH|
-030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54               |IJKLMNOPQRST|
+030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54 55 56 57 58   |IJKLMNOPQRSTUVWX|
+040: 59 5a 5b 5c 5d 5e 5f 60  61 62 63 64 65 00 00 00   |YZ[\]^_`abcde   |
 
 pattern_REGISTER_prep2:
 pktbuf:
@@ -70,7 +85,8 @@ pktbuf:
 010: 11 12 13 14 15 16 17 18  1c 1b 1a 19 1d 1e 1f 20   |                |
 020: 21 22 23 24 25 26 27 28  00 00 2c 2b 2d 2e 2f 30   |!"#$%&'(  ,+-./0|
 030: 40 3f 3e 3d 41 45 46 47  48 49 4a 4b 4c 4d 4e 4f   |@?>=AEFGHIJKLMNO|
-040: 50 51 52 53 54                                     |PQRST|
+040: 50 51 52 53 54 55 56 57  58 59 5a 5b 5c 5d 5e 5f   |PQRSTUVWXYZ[\]^_|
+050: 60 61 62 63 64 65                                  |`abcde|
 out_common:
 000: 01 02 40 00 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10   |  @             |
 010: 11 12 13 14 15 16 17 18                            |        |
@@ -78,7 +94,8 @@ out_data:
 000: 19 1a 1b 1c 1d 1e 1f 20  21 22 23 24 25 26 27 28   |        !"#$%&'(|
 010: 02 02 2b 2c 2d 2e 2f 30  00 00 00 00 00 00 00 00   |  +,-./0        |
 020: 00 00 00 00 3d 3e 3f 40  41 00 00 00 45 46 47 48   |    =>?@A   EFGH|
-030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54               |IJKLMNOPQRST|
+030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54 55 56 57 58   |IJKLMNOPQRSTUVWX|
+040: 59 5a 5b 5c 5d 5e 5f 60  61 62 63 64 65 00 00 00   |YZ[\]^_`abcde   |
 
 pattern_PACKET_prep1:
 pktbuf:
@@ -112,7 +129,8 @@ pktbuf:
 010: 11 12 13 14 15 16 17 18  1c 1b 1a 19 1d 1e 1f 20   |                |
 020: 21 22 3c 3b 3a 39 3d 41  42 43 44 45 46 47 48 49   |!"<;:9=ABCDEFGHI|
 030: 4a 4b 4c 4d 4e 4f 50 52  51 00 10 55 56 57 58 59   |JKLMNOPRQ  UVWXY|
-040: 5a 5b 5c 5d 5e 5f 60 61  62 63 64 88 87 86 85      |Z[\]^_`abcd    |
+040: 5a 5b 5c 5d 5e 5f 60 61  62 63 64 88 87 86 85 89   |Z[\]^_`abcd     |
+050: 8a 8b 8c 8d 8e 8f 90 91  92 93 94 95 96 97 98 99   |                |
 out_common:
 000: 01 02 00 04 05 06 07 08  09 0a 0b 0c 0d 0e 0f 10   |                |
 010: 11 12 13 14 15 16 17 18                            |        |
@@ -124,6 +142,8 @@ out_data:
 040: 59 5a 5b 5c 5d 5e 5f 60  61 62 63 64 00 00 00 00   |YZ[\]^_`abcd    |
 050: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
 060: 00 00 00 00 00 00 00 00  00 00 00 00 85 86 87 88   |                |
+070: 89 8a 8b 8c 8d 8e 8f 90  91 92 93 94 95 96 97 98   |                |
+080: 99 00 00 00                                        |    |
 
 pattern_UNREGISTER_SUPER_prep1:
 pktbuf:
@@ -146,7 +166,7 @@ pktbuf:
 010: 11 12 13 14 15 16 17 18  1c 1b 1a 19 1d 1e 1f 20   |                |
 020: 21 22 28 27 26 25 29 2e  2d 00 00 32 31 33 34 35   |!"('&%).-  21345|
 030: 36 44 43 00 10 47 48 49  4a 4b 4c 4d 4e 4f 50 51   |6DC  GHIJKLMNOPQ|
-040: 52 53 54 55 56 01 02 00  7f 80 81 82 83 84 00 00   |RSTUV           |
+040: 52 53 54 55 56 01 02 00  93 94 95 96 97 98 00 00   |RSTUV           |
 050: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
 060: 7c 7b 7a 79                                        ||{zy|
 out_common:
@@ -159,9 +179,10 @@ out_data:
 030: 49 4a 4b 4c 4d 4e 4f 50  51 52 53 54 55 56 00 00   |IJKLMNOPQRSTUV  |
 040: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00   |                |
 050: 00 00 00 00 00 00 00 00  00 00 00 00 00 00 01 00   |                |
-060: 79 7a 7b 7c                                        |yz{||
+060: 79 7a 7b 7c 00 00 00 00  00 00 00 00 00 00 00 00   |yz{|            |
+070: 00 00 00 00 00 00 00 00                            |        |
 out_tmpbuf:
-000: 02 00 7f 80 81 82 83 84  00 00 00 00 00 00 00 00   |                |
+000: 02 00 93 94 95 96 97 98  00 00 00 00 00 00 00 00   |                |
 010: 00 00 00 00 00 00 00 00  00 00                     |          |
 
 pattern_REGISTER_SUPER_NAK_prep1:

--- a/tools/tests-wire.c
+++ b/tools/tests-wire.c
@@ -653,6 +653,63 @@ void test_REGISTER_SUPER_no_ip6 (n2n_common_t *common) {
     fprintf(stderr, "%s: tested\n", test_name);
 }
 
+/*
+ * REGISTER_SUPER_ACK is the message that carries an assigned IPv6 subnet back
+ * to the edge, so round trip it and show what survives.  Encoding a field but
+ * forgetting to decode it (or the other way round) leaves the address silently
+ * unset, which looks exactly like a supernode that issued nothing.
+ */
+void test_REGISTER_SUPER_ACK_ip6 (n2n_common_t *common) {
+    char *test_name = "REGISTER_SUPER_ACK_ip6";
+
+    common->pc = MSG_TYPE_REGISTER_SUPER_ACK;
+
+    n2n_REGISTER_SUPER_ACK_t ack;
+    memset( &ack, 0, sizeof(ack) );
+    init_mac( ack.srcMac, 0x40,0x41,0x42,0x43,0x44,0x45);
+    init_ip_subnet(&ack.dev_addr);
+    init_ip6_subnet(&ack.dev_addr6);
+    init_auth(&ack.auth);
+    ack.lifetime = 60;
+    ack.num_sn = 0;
+    ack.key_time = 600;
+
+    /* The supernode always fills in the sender socket, and encode_sock() emits
+     * a different length per family, so set one rather than leaving it zero */
+    ack.sock.family = AF_INET6;
+    ack.sock.port = 7777;
+    memset(ack.sock.addr.v6, 0x5a, IPV6_SIZE);
+
+    print_ip6_subnet(test_name, "in  ack.dev_addr6", &ack.dev_addr6);
+
+    uint8_t pktbuf[N2N_PKT_BUF_SIZE];
+    uint8_t payload[REG_SUPER_ACK_PAYLOAD_SPACE];
+    memset(payload, 0, sizeof(payload));
+
+    size_t idx = 0;
+    encode_REGISTER_SUPER_ACK( pktbuf, &idx, common, &ack, payload);
+    printf("%s: encoded size = 0x%x\n", test_name, (uint32_t)idx);
+
+    n2n_common_t out_cmn;
+    n2n_REGISTER_SUPER_ACK_t out_ack;
+    uint8_t out_payload[REG_SUPER_ACK_PAYLOAD_SPACE];
+    size_t rem = idx;
+    size_t out_idx = 0;
+
+    memset(&out_cmn, 0, sizeof(out_cmn));
+    decode_common(&out_cmn, pktbuf, &rem, &out_idx);
+    decode_REGISTER_SUPER_ACK(&out_ack, &out_cmn, pktbuf, &rem, &out_idx, out_payload);
+
+    print_ip6_subnet(test_name, "out ack.dev_addr6", &out_ack.dev_addr6);
+    printf("%s: unconsumed bytes = %u\n", test_name, (uint32_t)rem);
+    printf("%s: dev_addr6 survived = %s\n",
+           test_name,
+           (memcmp(&ack.dev_addr6, &out_ack.dev_addr6, sizeof(ack.dev_addr6)) == 0) ? "yes" : "NO");
+
+    printf("\n");
+    fprintf(stderr, "%s: tested\n", test_name);
+}
+
 int main (int argc, char * argv[]) {
     char *test_name = "environment";
 
@@ -664,6 +721,7 @@ int main (int argc, char * argv[]) {
     test_REGISTER(&common);
     test_REGISTER_SUPER(&common);
     test_REGISTER_SUPER_no_ip6(&common);
+    test_REGISTER_SUPER_ACK_ip6(&common);
     test_UNREGISTER_SUPER(&common);
     // TODO: add more wire tests
 

--- a/tools/tests-wire.c
+++ b/tools/tests-wire.c
@@ -25,6 +25,7 @@
 #include <string.h>    // for memset, strcpy, strncpy
 #include "n2n.h"       // for n2n_common_t, n2n_REGISTER_SUPER_t, n2n_REGIST...
 #include "n2n_wire.h"  // for encode_REGISTER, encode_REGISTER_SUPER, encode...
+#include <n3n/strings.h> // for ip6_subnet_to_str
 
 
 void init_ip_subnet (n2n_ip_subnet_t * d) {
@@ -37,6 +38,22 @@ void print_ip_subnet (char *test_name, char *field, n2n_ip_subnet_t * d) {
            test_name, field, d->net_addr);
     printf("%s: %s.net_bitlen = %i\n",
            test_name, field, d->net_bitlen);
+}
+
+void init_ip6_subnet (n2n_ip6_subnet_t * d) {
+    // fd11:2233:4455:6677:8899:aabb:ccdd:eeff
+    static const uint8_t addr[IPV6_SIZE] = {
+        0xfd, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff
+    };
+    memcpy(d->net_addr, addr, sizeof(addr));
+    d->net_bitlen = 64;
+}
+
+void print_ip6_subnet (char *test_name, char *field, n2n_ip6_subnet_t * d) {
+    ip6_bit_str_t buf = {'\0'};
+    printf("%s: %s = %s\n",
+           test_name, field, ip6_subnet_to_str(buf, d));
 }
 
 void init_mac (n2n_mac_t mac, const uint8_t o0, const uint8_t o1,
@@ -96,6 +113,7 @@ void test_REGISTER (n2n_common_t *common) {
     init_mac( reg.srcMac, 0,1,2,3,4,5);
     init_mac( reg.dstMac, 0x10,0x11,0x12,0x13,0x14,0x15);
     init_ip_subnet(&reg.dev_addr);
+    init_ip6_subnet(&reg.dev_addr6);
     strcpy( (char *)reg.dev_desc, "Dummy_Dev_Desc" );
 
     printf("%s: reg.cookie = %i\n", test_name, reg.cookie);
@@ -104,6 +122,7 @@ void test_REGISTER (n2n_common_t *common) {
     // TODO: print reg.sock
     print_ip_subnet(test_name, "reg.dev_addr", &reg.dev_addr);
     printf("%s: reg.dev_desc = \"%s\"\n", test_name, reg.dev_desc);
+    print_ip6_subnet(test_name, "reg.dev_addr6", &reg.dev_addr6);
     printf("\n");
 
     uint8_t pktbuf[N2N_PKT_BUF_SIZE];
@@ -131,6 +150,7 @@ void test_REGISTER_SUPER (n2n_common_t *common) {
     init_mac( reg.edgeMac, 0x20,0x21,0x22,0x23,0x24,0x25);
     // n3n_sock_t sock
     init_ip_subnet(&reg.dev_addr);
+    init_ip6_subnet(&reg.dev_addr6);
     strcpy( (char *)reg.dev_desc, "Dummy_Dev_Desc" );
     init_auth(&reg.auth);
     reg.key_time = 600;
@@ -143,6 +163,7 @@ void test_REGISTER_SUPER (n2n_common_t *common) {
     printf("%s: reg.dev_desc = \"%s\"\n", test_name, reg.dev_desc);
     print_auth(test_name, "reg.auth", &reg.auth);
     printf("%s: reg.key_time = %u\n", test_name, (uint32_t)reg.key_time);
+    print_ip6_subnet(test_name, "reg.dev_addr6", &reg.dev_addr6);
     printf("\n");
 
     uint8_t pktbuf[N2N_PKT_BUF_SIZE];
@@ -565,6 +586,73 @@ void pattern_tests () {
 
 }
 
+/*
+ * The IPv6 subnet is appended to the end of REGISTER_SUPER, so a message from
+ * a peer that predates IPv6 support simply stops short.  Confirm that such a
+ * message still decodes, and that the optional field reads back as unset
+ * instead of picking up whatever bytes happen to follow.
+ *
+ * The trailing bytes matter here: when a shared secret is in use the sender
+ * appends an N2N_REG_SUP_HASH_CHECK_LEN byte hash which is still counted in
+ * the remaining length, so those bytes must not be mistaken for an address.
+ */
+void test_REGISTER_SUPER_no_ip6 (n2n_common_t *common) {
+    char *test_name = "REGISTER_SUPER_no_ip6";
+
+    common->pc = MSG_TYPE_REGISTER_SUPER;
+
+    n2n_REGISTER_SUPER_t reg;
+    memset( &reg, 0, sizeof(reg) );
+    init_mac( reg.edgeMac, 0x20,0x21,0x22,0x23,0x24,0x25);
+    init_ip_subnet(&reg.dev_addr);
+    init_ip6_subnet(&reg.dev_addr6);
+    strcpy( (char *)reg.dev_desc, "Dummy_Dev_Desc" );
+    init_auth(&reg.auth);
+    reg.key_time = 600;
+
+    uint8_t pktbuf[N2N_PKT_BUF_SIZE];
+    size_t idx = 0;
+    encode_REGISTER_SUPER( pktbuf, &idx, common, &reg);
+
+    /* Drop the encoded IPv6 subnet to imitate a sender without IPv6 support */
+    size_t truncated = idx - (IPV6_SIZE + 1);
+
+    struct {
+        char *name;
+        size_t extra;
+    } cases[] = {
+        { "truncated", 0 },
+        { "truncated_plus_hash", N2N_REG_SUP_HASH_CHECK_LEN },
+    };
+
+    for(unsigned int i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+        n2n_common_t out_common;
+        n2n_REGISTER_SUPER_t out_reg;
+        size_t out_idx = 0;
+
+        /* The hash bytes are opaque, any non zero pattern will do */
+        memset(pktbuf + truncated, 0xA5, cases[i].extra);
+
+        size_t rem = truncated + cases[i].extra;
+        decode_common(&out_common, pktbuf, &rem, &out_idx);
+        decode_REGISTER_SUPER(&out_reg, &out_common, pktbuf, &rem, &out_idx);
+
+        printf("%s: %s: dev_addr.net_addr = 0x%08x\n",
+               test_name, cases[i].name, out_reg.dev_addr.net_addr);
+        printf("%s: %s: key_time = %u\n",
+               test_name, cases[i].name, (uint32_t)out_reg.key_time);
+
+        char field[64];
+        snprintf(field, sizeof(field), "%s: dev_addr6", cases[i].name);
+        print_ip6_subnet(test_name, field, &out_reg.dev_addr6);
+        printf("%s: %s: unconsumed bytes = %u\n",
+               test_name, cases[i].name, (uint32_t)rem);
+    }
+
+    printf("\n");
+    fprintf(stderr, "%s: tested\n", test_name);
+}
+
 int main (int argc, char * argv[]) {
     char *test_name = "environment";
 
@@ -575,6 +663,7 @@ int main (int argc, char * argv[]) {
 
     test_REGISTER(&common);
     test_REGISTER_SUPER(&common);
+    test_REGISTER_SUPER_no_ip6(&common);
     test_UNREGISTER_SUPER(&common);
     // TODO: add more wire tests
 


### PR DESCRIPTION
 Add supernode-assigned IPv6 addresses for the TAP interface
  
  n3n already carries IPv6 inside the tunnel, but every address had to be added by hand. This adds an IPv6 counterpart to the existing IPv4 auto-address service: the supernode derives one /64 per community from a
  configurable prefix and assigns each edge an address out of it.

  New settings: tuntap.address6, tuntap.address6_mode (auto/static/dhcp, independent of the IPv4 mode) and supernode.auto_ip6_net. community.list takes an optional third column to pin a /64 to a community.

  Notes

  Host part comes from connection.description, not the MAC. The edge requests its address during bootstrap, before the TAP interface exists, so the MAC it reports is still all zeroes and would be identical for
  every edge. This is the same input the IPv4 allocator hashes.

  No protocol version bump. The subnet is appended after key_time in REGISTER, REGISTER_SUPER and REGISTER_SUPER_ACK. Existing decoders leave a truncated field at zero, so older peers interoperate. The field
  decodes atomically, because those messages may carry a trailing hash that is still counted in the remaining length.

  Transport fixes

  Two pre-existing bugs made IPv6 supernodes unreachable regardless of this feature:

  - The edge opened an IPv4 socket while sendto_sock() built IPv6 destinations, and the resulting EAFNOSUPPORT is logged at debug level — so it retried forever with no visible error. It now defaults to a
  dual-stack IPv6 socket like the supernode does, and builds destinations matching the socket's actual family.
  - detect_local_ip_address() and connection.advertise_addr were IPv4-only.

  Platform support

  Implemented everywhere IPv4 assignment already works: Linux, macOS, FreeBSD, OpenBSD, NetBSD, Windows. Also warns at startup when the MTU is below 1280 or filter.allow_multicast is off, since either silently
  breaks IPv6.

  Testing

  make test.builtin test.units passes; tests-wire.c gains a REGISTER_SUPER_ACK round-trip case and a truncated-message interop case.

  Verified end-to-end on Linux with privileges to create a real TAP interface. Not verified on real hardware for macOS, the BSDs or Windows — those are compile-checked only. make test.integration was not run.

  ---
  Same caveat as before: a1b059e (build fix for old kernel headers) and 6272d9c (macOS fake-autoconf script) aren't part of this feature, and a maintainer will likely want them split out. Say the word and I'll
  move them to their own branches.